### PR TITLE
Convert Eithers into Results.

### DIFF
--- a/src/analysis/decl_analysis.rs
+++ b/src/analysis/decl_analysis.rs
@@ -59,12 +59,12 @@ pub fn tParamDecl(_0: CDecl) -> m<ParamDecl> {
     }
 }
 
-pub fn computeParamStorage(_0: NodeInfo, _1: StorageSpec) -> Either<BadSpecifierError, Storage> {
+pub fn computeParamStorage(_0: NodeInfo, _1: StorageSpec) -> Result<Storage, BadSpecifierError> {
     match (_0, _1) {
-        (_, NoStorageSpec) => Right((Auto(false))),
-        (_, RegSpec) => Right((Auto(true))),
+        (_, NoStorageSpec) => Ok((Auto(false))),
+        (_, RegSpec) => Ok((Auto(true))),
         (node, spec) => {
-            Left(badSpecifierError(node,
+            Err(badSpecifierError(node,
                                    __op_addadd("Bad storage specified for parameter: "
                                                    .to_string(),
                                                show(spec))))

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -33254,7 +33254,7 @@ pub fn alex_actions() -> Vec<Box<Fn(Position, isize, InputStream) -> P<CToken>>>
         ])
 }
 
-pub fn readCOctal(s: String) -> Either<String, CInteger> {
+pub fn readCOctal(s: String) -> Result<CInteger, String> {
     if s.chars().nth(0).unwrap() == '0' {
         if s.len() > 1 && isDigit(s.chars().nth(1).unwrap()) {
             readCInteger(OctalRepr, s[1..].to_string())
@@ -33616,16 +33616,19 @@ pub fn token_fail(errmsg: String, pos: Position, _: isize, _: InputStream) -> P<
     failP(pos, vec!["Lexical Error !".to_string(), errmsg])
 }
 
-pub fn token<a>(mkTok: Box<Fn(PosLength, a) -> CToken>, fromStr: Box<Fn(String) -> a>, pos: Position, len: isize, __str: InputStream) -> P<CToken> {
+pub fn token<a>(mkTok: Box<Fn(PosLength, a) -> CToken>,
+                fromStr: Box<Fn(String) -> a>, pos: Position, len: isize, __str: InputStream) -> P<CToken> {
     __return((mkTok((pos, len), (fromStr(takeChars_str(len, __str))))))
 }
 
-pub fn token_plus<a>(mkTok: Box<Fn(PosLength, a) -> CToken>, fromStr: Box<Fn(String) -> Either<String, a>>, pos: Position, len: isize, __str: InputStream) -> P<CToken> {
+pub fn token_plus<a>(mkTok: Box<Fn(PosLength, a) -> CToken>,
+                     fromStr: Box<Fn(String) -> Result<a, String>>,
+                     pos: Position, len: isize, __str: InputStream) -> P<CToken> {
     match fromStr((takeChars_str(len, __str))) {
-        Left(err) => {
+        Err(err) => {
             failP(pos, vec!["Lexical error ! ".to_string(), err])
         },
-        Right(ok) => {
+        Ok(ok) => {
             __return(mkTok((pos, len), ok))
         },
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -28,9 +28,6 @@ use parser::parser_monad::ParseError;
 use data::position::Position;
 use data::input_stream::InputStream;
 
-pub fn execParser_<a: 'static>(parser: P<a>, input: InputStream, pos: Position) -> Either<ParseError, a> {
-    match execParser(parser, input, pos, builtinTypeNames(), newNameSupply()) {
-        Left(s) => Left(s),
-        Right((v, _)) => Right(v)
-    }
+pub fn execParser_<a: 'static>(parser: P<a>, input: InputStream, pos: Position) -> Result<a, ParseError> {
+    execParser(parser, input, pos, builtinTypeNames(), newNameSupply()).map(|(v, _)| v)
 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -41759,7 +41759,7 @@ pub fn appendDeclrAttrs(_0: Vec<CAttribute<NodeInfo>>, _1: CDeclrR) -> CDeclrR {
                             CFunDeclr(parameters, __op_addadd(cattrs, newAttrs), at),
                     }
                 };
-                
+
                 CDeclrR(ident, (Reversed((__op_concat(appendAttrs(x), xs)))), asmname, cattrs, at)
             }
         },
@@ -41891,7 +41891,7 @@ pub fn happyError<a: 'static>() -> P<a> {
     parseError()
 }
 
-pub fn parseC(input: InputStream, initialPosition: Position) -> Either<ParseError, CTranslationUnit<NodeInfo>> {
+pub fn parseC(input: InputStream, initialPosition: Position) -> Result<CTranslationUnit<NodeInfo>, ParseError> {
     execParser(translUnitP(), input, initialPosition, builtinTypeNames(), (namesStartingFrom(0)))
         .map(|x| x.0)
 }

--- a/src/parser/parser_monad.rs
+++ b/src/parser/parser_monad.rs
@@ -113,7 +113,7 @@ pub fn execParser<a>(P(parser): P<a>,
                      pos: Position,
                      builtins: Vec<Ident>,
                      names: Vec<Name>)
-                     -> Either<ParseError, (a, Vec<Name>)> {
+                     -> Result<(a, Vec<Name>), ParseError> {
 
     let initialState = PState {
         curPos: pos,
@@ -126,8 +126,8 @@ pub fn execParser<a>(P(parser): P<a>,
     };
 
     match parser(initialState) {
-        PFailed(message, errpos) => Left((ParseError((message, errpos)))),
-        POk(st, result) => Right((result, namesupply(st))),
+        PFailed(message, errpos) => Err(ParseError((message, errpos))),
+        POk(st, result) => Ok((result, namesupply(st))),
     }
 }
 

--- a/src/syntax/preprocess.rs
+++ b/src/syntax/preprocess.rs
@@ -19,7 +19,7 @@ use data::input_stream::*;
 // 'Preprocessor' encapsulates the abstract interface for invoking C preprocessors
 pub trait Preprocessor {
     // parse the given command line arguments, and return a pair of parsed and ignored arguments
-    fn parseCPPArgs(&self, Vec<String>, Either<String, String>) -> (CppArgs, Vec<String>);
+    fn parseCPPArgs(&self, Vec<String>, Result<String, String>) -> (CppArgs, Vec<String>);
     // run the preprocessor
     fn runCPP(&self, CppArgs) -> ExitCode;
 }
@@ -95,7 +95,7 @@ pub fn addExtraOption(cpp_args: CppArgs, extra: String) -> CppArgs {
 
 pub fn runPreprocessor<P: Preprocessor>(cpp: P,
                                         cpp_args: CppArgs)
-                                        -> Either<ExitCode, InputStream> {
+                                        -> Result<InputStream, ExitCode> {
 
     pub fn getActualOutFile(cpp_args: CppArgs) -> FilePath {
         outputFile(cpp_args.clone())
@@ -113,8 +113,8 @@ pub fn runPreprocessor<P: Preprocessor>(cpp: P,
             }));
 
             match exit_code {
-                ExitSuccess => Right(readInputStream(actual_out_file)),
-                ExitFailure(_) => Left(exit_code),
+                ExitSuccess => Ok(readInputStream(actual_out_file)),
+                ExitFailure(_) => Err(exit_code),
             }
         }
     };


### PR DESCRIPTION
I have only done this where the Left variant was an obvious error
indication.  There are a few Eithers left that can either stay
(use the either crate in that case?) or be replaced by domain-specific
enums.

Changes in `analysis` are unchecked, see #9.

Fixes #3