### PR TITLE
Remove a lot of clones from parser/lexer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 .vscode
+.stack-work
+reference/stack.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ dependencies = [
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "parser-c-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parser-c-macro 0.1.0",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -128,7 +128,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "parser-c-macro"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -277,7 +276,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d1891bd7b936f12349b7d1403761c8a0b85a18b148e9da4429d5d102c1a41e"
 "checksum num-rational 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "c2dc5ea04020a8f18318ae485c751f8cfa1c0e69dcf465c29ddaaa64a313cc44"
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
-"checksum parser-c-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4305b399fce452172a8c6a34f30ce3f139220b332199c858f8307a70bd32ab08"
 "checksum quote 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b0f1847d90ff21d41b08f7f9f8e82dff613c3e2c5ebc9f8a10aeee1a0c4d7d17"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 num = "0.1"
 num-derive = "0.1"
-parser-c-macro = "0.1.0"
+parser-c-macro = { path = "parser-c-macro" }
 matches = "0.1.6"
 lazy_static = "0.2"
 

--- a/parser-c-macro/src/lib.rs
+++ b/parser-c-macro/src/lib.rs
@@ -4,68 +4,28 @@
 extern crate proc_macro;
 extern crate syn;
 #[macro_use] extern crate quote;
-extern crate regex;
 
 use syn::{ Ident, Body, Variant, VariantData };
 use proc_macro::TokenStream;
 use quote::{ToTokens, Tokens};
-use regex::{Regex, Captures};
 
 #[proc_macro]
 pub fn refute(input: TokenStream) -> TokenStream {
     let input = input.to_string();
 
-    // Replace things with clones.
-    // let mut clones: Vec<String> = vec![];
-    // for item in Regex::new(r#"happy_var_\d+"#).unwrap().captures_iter(&input) {
-        // clones.push(format!("let {} = {}.clone();", &item[0], &item[0]));
-    // }
-    let r = Regex::new(r#"box\s*(?:move\s*)?(\|\s*(at|_0)[^|]*\|\s*\{)"#).unwrap();
-    // println!("{:?} clones {:?}", input, clones);
-    let input: String = r.replace(input.as_ref(), format!(r#"box move $1 "#).as_str()).to_string();
-    // println!("{:?} clones {:?}", input, clones);
-
-    let input = if input.find("clones !").is_none() {
-        Regex::new(r#"((?:\bwith[A-Za-z_0-9]+)[\s\S]+?box move \| (?:at|_0)[^|]+\|)([\s\S]*)(box move)"#)
-        .unwrap().replace_all(&input, |cap: &Captures| {
-            format!("{}{}{}",
-                &cap[1],
-                Regex::new(r#"happy_var_\d+"#).unwrap().replace_all(&cap[2], "$0.clone()"),
-                &cap[3])
-        }).to_string()
-    } else {
-        input
-    };
-    let input = Regex::new(r#"((?:\bwith[A-Za-z_0-9]+)[\s\S]+box move[\s\S\+]box move \| (?:at|_0)[^|]+\|)([\s\S]*)(box move)"#)
-    .unwrap().replace_all(&input, |cap: &Captures| {
-        format!("{}{}{}",
-            &cap[1],
-            Regex::new(r#"happy_var_\d+"#).unwrap().replace_all(&cap[2], "$0.clone()"),
-            &cap[3])
-    });
-
-    let input = Regex::new(r#"((?:\bwith[A-Za-z0-9]+)[\s\S]+partial_1\s*!\s*\(\s*)([\s\S]*)(box move)"#).unwrap().replace_all(&input, |cap: &Captures| {
-        format!("{}{}{}",
-            &cap[1],
-            Regex::new(r#"happy_var_\d+"#).unwrap().replace_all(&cap[2], "$0.clone()"),
-            &cap[3])
-    });
-
 // 35834 |    refute!( pub fn happyReduction_23<t>(HappyStk(HappyAbsSyn12(happy_var_4), box HappyStk(HappyAbsSyn33(happy_var_3), box HappyStk(HappyAbsSyn11(happy_var_2), box HappyStk(HappyAbsSyn38(happy_var_1), box happyRest)))): HappyStk<HappyAbsSyn>, tk: t) -> P<HappyAbsSyn> {
-
-      // match withNodeInfo ... partial1(...) and replace happy_var_1 elements with .clone()
 
     let mut ast = syn::parse_item(&input).unwrap();
 
-    match &mut ast.node {
-        &mut syn::ItemKind::Fn(ref mut decl, _, _, _, _, ref mut body) => {
+    match ast.node {
+        syn::ItemKind::Fn(ref mut decl, _, _, _, _, ref mut body) => {
             let mut pat_expand = vec![];
             for (i, arg) in decl.inputs.iter_mut().enumerate() {
-                match arg {
-                    &mut syn::FnArg::Captured(ref mut pat, _) => {
+                match *arg {
+                    syn::FnArg::Captured(ref mut pat, _) => {
                         pat_expand.push(pat.clone());
                         *pat = syn::Pat::Ident(syn::BindingMode::ByValue(syn::Mutability::Immutable),
-                            syn::Ident::new(format!("_{}", i)), None);
+                                               syn::Ident::new(format!("_{}", i)), None);
                     }
                     _ => {
                         println!("TODO");
@@ -75,14 +35,14 @@ pub fn refute(input: TokenStream) -> TokenStream {
 
             let body_inner: syn::Block = (**body).clone();
 
-
-
             *body = Box::new(syn::Block {
                 stmts: vec![
                     syn::Stmt::Expr(Box::new(syn::Expr {
                         node: syn::ExprKind::Match(
-                            Box::new(syn::parse_expr(&format!("({})", 
-                                (0..pat_expand.len()).map(|x| format!("{{ _{} }}", x)).collect::<Vec<_>>().join(", ")
+                            Box::new(syn::parse_expr(&format!(
+                                "({})",
+                                (0..pat_expand.len()).map(|x| format!("{{ _{} }}", x))
+                                                     .collect::<Vec<_>>().join(", ")
                             )).unwrap()),
                             vec![
                                 syn::Arm {
@@ -122,7 +82,7 @@ pub fn refute(input: TokenStream) -> TokenStream {
     // if input.find("happyReduction_315").is_some() {
     //     println!("OH {:?}", args.to_string());
     // }
-    
+
     args.parse().unwrap()
 }
 
@@ -130,13 +90,13 @@ pub fn refute(input: TokenStream) -> TokenStream {
 pub fn cnodeable(input: TokenStream) -> TokenStream {
     // Construct a string representation of the type definition
     let s = input.to_string();
-    
+
     // Parse the string representation
     let ast = syn::parse_macro_input(&s).unwrap();
 
     // Build the impl
     let gen = impl_cnodeable(&ast);
-    
+
     // Return the generated impl
     gen.parse().unwrap()
 }

--- a/src/data/error.rs
+++ b/src/data/error.rs
@@ -118,7 +118,7 @@ pub struct UnsupportedFeature(pub String, pub Position);
 
 
 pub fn unsupportedFeature<P: Pos>(msg: String, a: P) -> UnsupportedFeature {
-    UnsupportedFeature(msg, a.posOf())
+    UnsupportedFeature(msg, a.into_pos())
 }
 
 pub fn unsupportedFeature_(msg: String) -> UnsupportedFeature {

--- a/src/data/error.rs
+++ b/src/data/error.rs
@@ -39,7 +39,7 @@ pub struct ErrorInfo(pub ErrorLevel, pub Position, pub Vec<String>);
 
 
 pub fn mkErrorInfo(lvl: ErrorLevel, msg: String, node: NodeInfo) -> ErrorInfo {
-    ErrorInfo(lvl, node.pos(), lines(msg))
+    ErrorInfo(lvl, node.into_pos(), lines(msg))
 }
 
 #[derive(Debug)]

--- a/src/data/ident.rs
+++ b/src/data/ident.rs
@@ -70,7 +70,7 @@ impl CNode for Ident {
 
 impl Pos for Ident {
     fn posOf(self) -> Position {
-        nodeInfo(self).pos()
+        nodeInfo(self).into_pos()
     }
 }
 
@@ -94,7 +94,7 @@ impl Ident {
     }
 
     pub fn is_internal(&self) -> bool {
-        self.1.pos_ref().isInternal()
+        self.1.pos().isInternal()
     }
 
     pub fn to_string(self) -> String {

--- a/src/data/ident.rs
+++ b/src/data/ident.rs
@@ -62,15 +62,11 @@ impl PartialEq for Ident {
 
 // -- identifiers are attributed
 impl CNode for Ident {
-    fn nodeInfo(self) -> NodeInfo {
-        let Ident(_, at) = self;
-        at
+    fn node_info(&self) -> &NodeInfo {
+        &self.1
     }
-}
-
-impl Pos for Ident {
-    fn posOf(self) -> Position {
-        nodeInfo(self).into_pos()
+    fn into_node_info(self) -> NodeInfo {
+        self.1
     }
 }
 

--- a/src/data/ident.rs
+++ b/src/data/ident.rs
@@ -25,44 +25,45 @@ pub enum SUERef {
 }
 pub use self::SUERef::*;
 
-pub fn isAnonymousRef(_0: SUERef) -> bool {
-    match (_0) {
-        AnonymousRef(_) => true,
-        _ => false,
+impl SUERef {
+    pub fn is_anonymous(&self) -> bool {
+        match *self {
+            AnonymousRef(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn to_string(self) -> String {
+        match self {
+            AnonymousRef(_) => "".into(),
+            NamedRef(ident) => ident.to_string(),
+        }
     }
 }
 
 #[derive(Clone, Debug, PartialOrd, Eq)]
-pub struct Ident(pub String, pub isize, pub NodeInfo);
+pub struct Ident(pub String, pub NodeInfo);
 
 // required because we keep Idents in a HashSet and don't want the set to
 // consider the NodeInfo part important for comparison
 impl Hash for Ident {
     fn hash<H: Hasher>(&self, h: &mut H) {
         (self.0).hash(h);
-        (self.1).hash(h);
     }
 }
 
 // the definition of the equality allows identifiers to be equal that are
-// defined at different source text positions, and aims at speeding up the
-// equality test, by comparing the lexemes only if the two numbers are equal
+// defined at different source text positions
 impl PartialEq for Ident {
-    fn eq(&self, &Ident(ref s_, ref h_, _): &Self) -> bool {
-        let &Ident(ref s, ref h, _) = self;
-        (h == h_) && (s == s_)
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
     }
 }
-
-// -- this does *not* follow the alphanumerical ordering of the lexemes
-// --
-// instance Ord Ident where
-//   compare (Ident s h _) (Ident s' h' _) = compare (h, s) (h', s')
 
 // -- identifiers are attributed
 impl CNode for Ident {
     fn nodeInfo(self) -> NodeInfo {
-        let Ident(_, _, at) = self;
+        let Ident(_, at) = self;
         at
     }
 }
@@ -73,79 +74,35 @@ impl Pos for Ident {
     }
 }
 
-pub fn quad(_0: String) -> isize {
-    let c: Vec<char> = _0.chars().collect();
-
-    // [c1, c2, c3, c4, s..]
-    if c.len() > 3 {
-        let s: String = c[4..].to_vec().into_iter().collect();
-        return ((__mod(((ord(c[3]) *
-                    (bits21() + (ord(c[2]) * (bits14() + (ord(c[1]) * (bits7() + ord(c[0])))))))),
-                bits28())) + (__mod(quad(s), bits28())));
+impl Ident {
+    pub fn new(pos: Position, s: String, name: Name) -> Ident {
+        let len = s.len() as isize;
+        Ident(s, NodeInfo::new(pos.clone(), (pos, len), name))
     }
-    // [c1, c2, c3]
-    if c.len() == 3 {
-        return (ord(c[2]) * (bits14() + (ord(c[1]) * (bits7() + ord(c[2])))));
+
+    pub fn internal(s: String) -> Ident {
+        Ident(s, NodeInfo::with_only_pos(Position::internal()))
     }
-    // [c1, c2]
-    if c.len() == 2 { 
-        return (ord(c[1]) * (bits7() + ord(c[0])));
+
+    pub fn internal_at(pos: Position, s: String) -> Ident {
+        let len = s.len() as isize;
+        Ident(s, NodeInfo::with_pos_len(pos.clone(), (pos, len)))
     }
-    // [c1]
-    if c.len() == 1 {
-        return ord(c[0]);
+
+    pub fn builtin(s: String) -> Ident {
+        Ident(s, NodeInfo::with_only_pos(Position::builtin()))
     }
-    // []
-    return 0;
-}
 
-pub fn bits7() -> isize {
-    __op_power(2, (7))
-}
-
-pub fn bits14() -> isize {
-    __op_power(2, (14))
-}
-
-pub fn bits21() -> isize {
-    __op_power(2, (21))
-}
-
-pub fn bits28() -> isize {
-    __op_power(2, (28))
-}
-
-pub fn mkIdent(pos: Position, s: String, name: Name) -> Ident {
-    Ident(s.clone(), quad(s.clone()), NodeInfo::new(pos.clone(), (pos, s.len() as isize), name))
-}
-
-pub fn internalIdent(s: String) -> Ident {
-    Ident(s.clone(), quad(s.clone()), NodeInfo::with_only_pos(Position::internal()))
-}
-
-pub fn internalIdentAt(pos: Position, s: String) -> Ident {
-    Ident(s.clone(), quad(s.clone()), NodeInfo::with_pos_len(pos.clone(), (pos, s.len() as isize)))
-}
-
-pub fn builtinIdent(s: String) -> Ident {
-    Ident(s.clone(), quad(s.clone()), NodeInfo::with_only_pos(Position::builtin()))
-}
-
-pub fn isInternalIdent(Ident(_, _, nodeinfo): Ident) -> bool {
-    nodeinfo.pos().isInternal()
-}
-
-pub fn identToString(Ident(s, _, _): Ident) -> String {
-    s
-}
-
-pub fn sueRefToString(_0: SUERef) -> String {
-    match (_0) {
-        AnonymousRef(_) => "".to_string(),
-        NamedRef(ident) => identToString(ident),
+    pub fn is_internal(&self) -> bool {
+        self.1.pos_ref().isInternal()
     }
-}
 
-pub fn dumpIdent(ide: Ident) -> String {
-    format!("{:?} at {:?}", identToString(ide.clone()), ide.nodeInfo())
+    pub fn to_string(self) -> String {
+        self.0
+    }
+
+    // TODO: should this be a Debug impl?
+    pub fn dump(&self) -> String {
+        format!("{:?} at {:?}", self.0, self.1)
+    }
 }

--- a/src/data/ident.rs
+++ b/src/data/ident.rs
@@ -12,6 +12,8 @@ use corollary_support::*;
 // use Name;
 // use Data::Generics;
 
+use std::hash::{Hash, Hasher};
+
 use data::position::*;
 use data::node::*;
 use data::name::Name;
@@ -30,8 +32,17 @@ pub fn isAnonymousRef(_0: SUERef) -> bool {
     }
 }
 
-#[derive(Clone, Debug, PartialOrd, Hash, Eq)]
+#[derive(Clone, Debug, PartialOrd, Eq)]
 pub struct Ident(pub String, pub isize, pub NodeInfo);
+
+// required because we keep Idents in a HashSet and don't want the set to
+// consider the NodeInfo part important for comparison
+impl Hash for Ident {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        (self.0).hash(h);
+        (self.1).hash(h);
+    }
+}
 
 // the definition of the equality allows identifiers to be equal that are
 // defined at different source text positions, and aims at speeding up the

--- a/src/data/input_stream.rs
+++ b/src/data/input_stream.rs
@@ -4,47 +4,62 @@
 #[macro_use]
 use corollary_support::*;
 
-// NOTE: These imports are advisory. You probably need to change them to support Rust.
-// use Data::Word;
-// use Data::ByteString;
-// use ByteString;
-// use Data::ByteString;
-// use Data::ByteString::Char8;
-// use Data::Char;
+use std::rc::Rc;
+use std::fs::File;
+use std::io::Read;
 
-pub type InputStream = ByteString;
-
-pub fn takeByte(bs: InputStream) -> (Word8, InputStream) {
-    seq(BSW::head(bs.clone()), (BSW::head(bs.clone()), BSW::tail(bs)))
+#[derive(Clone, Debug)]
+pub struct InputStream {
+    src: Rc<Vec<u8>>,
+    pos: usize,
 }
 
-pub fn takeChar(bs: InputStream) -> (char, InputStream) {
-    seq(BSC::head(bs.clone()), (BSC::head(bs.clone()), BSC::tail(bs)))
-}
+impl InputStream {
 
-pub fn inputStreamEmpty(bs: InputStream) -> bool {
-    BSW::null(bs)
-}
+    pub fn from_file(f: &FilePath) -> InputStream {
+        let mut src = vec![];
+        File::open(&f.path).unwrap().read_to_end(&mut src).unwrap();
+        InputStream { src: Rc::new(src), pos: 0 }
+    }
 
-pub fn takeChars(n: isize, bstr: InputStream) -> Vec<char> {
-    BSC::unpack(BSC::take(n, bstr)).chars().collect()
-}
+    pub fn from_string(src: String) -> InputStream {
+        InputStream { src: Rc::new(src.into_bytes()), pos: 0 }
+    }
 
-pub fn takeChars_str(n: isize, bstr: InputStream) -> String {
-    BSC::unpack(BSC::take(n, bstr)).chars().collect()
-}
-pub fn readInputStream(f: FilePath) -> InputStream {
-    BSW::readFile(f)
-}
+    pub fn to_string(self) -> String {
+        String::from_utf8_lossy(&self.src[self.pos..]).into_owned()
+    }
 
-pub fn inputStreamToString(bs: InputStream) -> String {
-    BSC::unpack(bs)
-}
+    pub fn is_empty(&self) -> bool {
+        self.pos == self.src.len()
+    }
 
-pub fn inputStreamFromString(s: String) -> InputStream {
-    BSC::pack(s)
-}
+    pub fn take_byte(mut self) -> (u8, InputStream) {
+        let pos = self.pos;
+        let byte = self.src[pos];
+        self.pos += 1;
+        (byte, self)
+    }
 
-pub fn countLines(bs: InputStream) -> isize {
-    length(BSC::lines(bs))
+    // TODO correct unicode char handling
+
+    pub fn take_char(mut self) -> (char, InputStream) {
+        let pos = self.pos;
+        let ch = self.src[pos] as char;
+        self.pos += 1;
+        (ch, self)
+    }
+
+    pub fn take_char_vec(self, n: isize) -> Vec<char> {
+        self.src[self.pos..].iter().take(n as usize).map(|&x| x as char).collect()
+    }
+
+    pub fn take_string(self, n: isize) -> String {
+        self.src[self.pos..].iter().take(n as usize).map(|&x| x as char).collect()
+    }
+
+    pub fn count_lines(self) -> isize {
+        // TODO
+        self.to_string().lines().count() as isize
+    }
 }

--- a/src/data/name.rs
+++ b/src/data/name.rs
@@ -1,21 +1,11 @@
 // Original file: "Name.hs"
 // File auto-generated using Corollary.
 
-#[macro_use]
-use corollary_support::*;
-
-// NOTE: These imports are advisory. You probably need to change them to support Rust.
-// use Data::Ix;
-// use Data::Generics;
-
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
-pub struct Name(pub isize);
+pub struct Name(usize);
 
-pub fn newNameSupply() -> Vec<Name> {
-    namesStartingFrom(0)
-}
+pub type NameSupply = Box<Iterator<Item=Name>>;
 
-pub fn namesStartingFrom(k: isize) -> Vec<Name> {
-    // TODO fix this to be an infinite iterator
-    (0..1024).map(|k| Name(k)).collect()
+pub fn new_name_supply() -> NameSupply {
+    Box::new((0..).map(Name))
 }

--- a/src/data/node.rs
+++ b/src/data/node.rs
@@ -107,10 +107,18 @@ impl NodeInfo {
         }
     }
 
+    // TODO: necessary, or is pos_ref enough?
     pub fn pos(self) -> Position {
         match self {
             OnlyPos(pos, _) => pos,
             NodeInfo(pos, _, _) => pos,
+        }
+    }
+
+    pub fn pos_ref(&self) -> &Position {
+        match *self {
+            OnlyPos(ref pos, _) => pos,
+            NodeInfo(ref pos, _, _) => pos,
         }
     }
 }

--- a/src/data/position.rs
+++ b/src/data/position.rs
@@ -4,9 +4,6 @@
 #[macro_use]
 use corollary_support::*;
 
-// NOTE: These imports are advisory. You probably need to change them to support Rust.
-// use Data::Generics;
-
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub enum Position {
     Position {
@@ -135,10 +132,8 @@ impl Position {
 
 pub type PosLength = (Position, isize);
 
-// class of type which aggregate a source code location
+// class of types which aggregate a source code location
 pub trait Pos {
-    fn posOf(self) -> Position;
-}
-pub fn posOf<P: Pos>(input: P) -> Position {
-    input.posOf()
+    fn pos(&self) -> &Position;
+    fn into_pos(self) -> Position;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,11 +54,10 @@ use support as corollary_support;
 use corollary_support::*;
 use syntax::preprocess::*;
 use syntax::ast::*;
-use data::input_stream::readInputStream;
+use data::input_stream::InputStream;
 use data::position::Position;
 use parser::parser_monad::ParseError;
 use parser::parser::parseC;
-use data::input_stream::inputStreamFromString;
 
 // NOTE: These imports are advisory. You probably need to change them to support Rust.
 // use Language::C::Data;
@@ -85,7 +84,7 @@ fn parseCFile<C: Preprocessor>(cpp: C,
 
         handleCppError(runPreprocessor(cpp, cpp_args))
     } else {
-        readInputStream(input_file.clone())
+        InputStream::from_file(&input_file)
     };
 
     parseC(input_stream, Position::from_file(input_file))
@@ -93,7 +92,7 @@ fn parseCFile<C: Preprocessor>(cpp: C,
 
 pub fn parseCFilePre(file: FilePath) -> Result<CTranslUnit, ParseError> {
     thread::Builder::new().stack_size(32 * 1024 * 1024).spawn(move || {
-        let input_stream = readInputStream(file.clone());
+        let input_stream = InputStream::from_file(&file);
         parseC(input_stream, Position::from_file(file))
     }).unwrap().join().unwrap()
 }
@@ -108,7 +107,7 @@ pub fn parse(input: &str, filename: &str) -> Result<CTranslUnit, ParseError> {
 
     // TODO which stack size is necessary? Can we eliminate this?
     thread::Builder::new().stack_size(32 * 1024 * 1024).spawn(move || {
-        let input_stream = inputStreamFromString(input);
+        let input_stream = InputStream::from_string(input);
 
         parseC(input_stream, Position::from_file(FilePath::from(filename)))
     }).unwrap().join().unwrap()

--- a/src/parser/Lexer.x
+++ b/src/parser/Lexer.x
@@ -146,7 +146,7 @@ $white+         ;
 --
 \#$space*@int$space*(\"($infname|@charesc)*\"$space*)?(@int$space*)*\r?$eol
   {
-    seqP(setPos(adjustLineDirective(len, takeChars_str(len, inp), pos)), lexToken_q(false))
+    seqP(setPos(adjustLineDirective(inp.take_string(len), pos)), lexToken_q(false))
   }
 
 -- #pragma directive (K&R A12.8)
@@ -165,7 +165,7 @@ $white+         ;
 
 -- identifiers and keywords (follows K&R A2.3 and A2.4)
 --
-$identletter($identletter|$digit)*   { idkwtok(takeChars_str(len, inp), pos) }
+$identletter($identletter|$digit)*   { idkwtok(inp.take_string(len), pos) }
 
 -- constants (follows K&R A2.5)
 --
@@ -447,37 +447,23 @@ pub fn tok(len: isize, tc: Box<Fn(PosLength) -> CToken>, pos: Position) -> P<CTo
     returnP(tc((pos, len)))
 }
 
-pub fn adjustLineDirective(pragmaLen: isize, __str: String, pos: Position) -> Position {
-    fn dropWhite(input: String) -> String {
-        dropWhile((|c| { (c == ' ') || (c == '\t') }), input)
-    }
+pub fn adjustLineDirective(pragma: String, pos: Position) -> Position {
+    // note: it is ensured by the lexer that the requisite parts of the line are present
+    // so we just use unwrap()
 
-    // TODO cleanup
-    let offs_q = pos.offset() + pragmaLen;
+    // calculate new offset
+    let offs_q = pos.offset() + pragma.len() as isize;
+    // get the row
+    let row = pragma[1..].split_whitespace().next().unwrap().parse().unwrap();
+    // next, the filename
+    // TODO this isn't necessarily very nice
+    let fname_start = pragma.as_bytes().iter().position(|&ch| ch == b'"').unwrap();
+    let fname_end = pragma[fname_start+1..].as_bytes().iter().position(|&ch| ch == b'"').unwrap();
+    let fname = &pragma[fname_start+1..fname_start+fname_end+1];
 
-    let str_q = dropWhite(drop_str(1, __str));
-
-    let (rowStr, str_q_q) = span(isDigit, str_q);
-
-    // from read(rowStr)
-    let row_q = isize::from_str(&rowStr).unwrap();
-
-    let str_q_q_q = dropWhite(str_q_q);
-
-    let fnameStr = takeWhile_str(|x| { x != '\"' }, drop_str(1, str_q_q_q.clone()));
-
-    let fname = pos.file();
-
-    let fname_q = if str_q_q_q.len() == 0 || head_str(str_q_q_q) != '"' {
-        fname
-    } else if fnameStr == fname {
-        // try and get more sharing of file name strings
-        fname
-    } else {
-        fnameStr
-    };
-
-    Position::new(offs_q, fname_q, row_q, 1)
+    let current_fname = pos.file();
+    let new_fname = if current_fname == fname { current_fname } else { fname.to_string() };
+    Position::new(offs_q, new_fname, row, 1)
 }
 
 /// special utility for the lexer
@@ -508,14 +494,14 @@ pub fn token_fail(errmsg: &str, pos: Position, _: isize, _: InputStream) -> P<CT
 /// token that uses the string
 pub fn token<a>(mkTok: Box<Fn(PosLength, a) -> CToken>,
                 fromStr: Box<Fn(String) -> a>, pos: Position, len: isize, __str: InputStream) -> P<CToken> {
-    returnP(mkTok((pos, len), fromStr(takeChars_str(len, __str))))
+    returnP(mkTok((pos, len), fromStr(__str.take_string(len))))
 }
 
 /// token that may fail
 pub fn token_plus<a>(mkTok: Box<Fn(PosLength, a) -> CToken>,
                      fromStr: Box<Fn(String) -> Result<a, String>>,
                      pos: Position, len: isize, __str: InputStream) -> P<CToken> {
-    match fromStr(takeChars_str(len, __str)) {
+    match fromStr(__str.take_string(len)) {
         Err(err) => {
             failP(pos, vec!["Lexical error ! ".to_string(), err])
         },
@@ -534,13 +520,12 @@ pub fn alexInputPrevChar(_: AlexInput) -> char {
     panic!("alexInputPrevChar not used")
 }
 
-pub fn alexGetByte((p, is): AlexInput) -> Option<(Word8, AlexInput)> {
-    // No clone after removing ByteString API
-    if inputStreamEmpty(is.clone()) {
+pub fn alexGetByte((p, is): AlexInput) -> Option<(u8, AlexInput)> {
+    if is.is_empty() {
         None
     } else {
-        let (b, s) = takeByte(is);
-        // this is safe for latin-1, but ugly
+        let (b, s) = is.take_byte();
+        // TODO this is safe for latin-1, but ugly
         let p_q = alexMove(p, chr(fromIntegral(b as isize)));
         Some((b, (p_q, s)))
     }
@@ -557,8 +542,8 @@ pub fn alexMove(pos: Position, ch: char) -> Position {
 
 pub fn lexicalError<a: 'static>() -> P<a> {
     thenP(getPos(), box move |pos: Position| {
-        thenP(getInput(), box move |input| {
-            let (c, _) = takeChar(input);
+        thenP(getInput(), box move |input: InputStream| {
+            let (c, _) = input.take_char();
             failP(pos, vec![
                 "Lexical error !".to_string(),
                 format!("The character {} does not fit here.", c),

--- a/src/parser/Lexer.x
+++ b/src/parser/Lexer.x
@@ -415,7 +415,7 @@ pub fn idkwtok(id: String, pos: Position) -> P<CToken> {
                 getNewName(),
                 box move |name| {
                     let len = id.len() as isize;
-                    let ident = mkIdent(pos.clone(), id, name);
+                    let ident = Ident::new(pos.clone(), id, name);
 
                     thenP(isTypeIdent(ident.clone()), box move |tyident| {
                         if tyident {
@@ -554,7 +554,7 @@ pub fn lexicalError<a: 'static>() -> P<a> {
 
 pub fn parseError<a: 'static>() -> P<a> {
     thenP(getLastToken(), box move |lastTok: CToken| {
-        failP(posOf(lastTok.clone()), vec![
+        failP(lastTok.clone().into_pos(), vec![
             "Syntax error !".to_string(),
             format!("The symbol `{}' does not fit here.", lastTok)
         ])

--- a/src/parser/Lexer.x
+++ b/src/parser/Lexer.x
@@ -559,7 +559,7 @@ pub fn alexMove(pos: Position, ch: char) -> Position {
 }
 
 pub fn lexicalError<a: 'static>() -> P<a> {
-    thenP(getPos(), box move |pos| {
+    thenP(getPos(), box move |pos: Position| {
         thenP(getInput(), box move |input| {
             let (c, _) = takeChar(input);
             let pos = pos.clone();
@@ -572,7 +572,7 @@ pub fn lexicalError<a: 'static>() -> P<a> {
 }
 
 pub fn parseError<a: 'static>() -> P<a> {
-    thenP(getLastToken(), box move |lastTok| {
+    thenP(getLastToken(), box move |lastTok: CToken| {
         failP(posOf(lastTok.clone()), vec![
             "Syntax error !".to_string(),
             format!("The symbol `{}' does not fit here.", lastTok)
@@ -598,35 +598,28 @@ pub fn lexToken() -> P<CToken> {
 }
 
 pub fn lexToken_q(modifyCache: bool) -> P<CToken> {
-    thenP(getPos(), box move |pos| {
-
-        thenP(getInput(), box move |inp| {
-            let pos = pos.clone();
-
+    thenP(getPos(), box move |pos: Position| {
+        thenP(getInput(), box move |inp: InputStream| {
             match alexScan((pos.clone(), inp.clone()), 0) {
                 AlexEOF => {
-                    thenP(handleEofToken(), box move |_| __return(CTokEof))
+                    rshift_monad(handleEofToken(), returnP(CTokEof))
                 },
                 AlexError(_inp) => {
                     lexicalError()
                 },
                 AlexSkip((pos_q, inp_q), _len) => {
-                    let _0 = setPos(pos_q);
-                    let _1 = setInput(inp_q);
-                    let _2 = lexToken_q(modifyCache);
-                    thenP(_0, box move |_| { let _2 = _2.clone(); thenP(_1.clone(), box move |_| _2.clone()) })
+                    rshift_monad(setPos(pos_q), rshift_monad(setInput(inp_q), lexToken_q(modifyCache)))
                 },
                 AlexToken((pos_q, inp_q), len, action) => {
-                    let _0 = setPos(pos_q);
-                    let _1 = setInput(inp_q);
-                    let _2 = thenP(action(pos, len, inp), box move |nextTok| {
-                        if modifyCache {
-                            thenP(setLastToken(nextTok.clone()), box move |_| __return(nextTok.clone()))
-                        } else {
-                            __return(nextTok)
-                        }
-                    });
-                    thenP(_0, box move |_| { let _2 = _2.clone(); thenP(_1.clone(), box move |_| _2.clone()) })
+                    rshift_monad(setPos(pos_q), rshift_monad(
+                        setInput(inp_q),
+                        thenP(action(pos, len, inp), box move |nextTok: CToken| {
+                            if modifyCache {
+                                rshift_monad(setLastToken(nextTok.clone()), returnP(nextTok))
+                            } else {
+                                returnP(nextTok)
+                            }
+                        })))
                 },
             }
         })
@@ -634,9 +627,7 @@ pub fn lexToken_q(modifyCache: bool) -> P<CToken> {
 }
 
 pub fn lexC<a: 'static>(cont: Box<Fn(CToken) -> P<a>>) -> P<a> {
-    thenP(lexToken(), box move |nextTok| {
-        cont(nextTok)
-    })
+    thenP(lexToken(), box move |tok| cont(tok))
 }
 
 }

--- a/src/parser/Parser.y
+++ b/src/parser/Parser.y
@@ -52,7 +52,7 @@ use data::name::*;
 use syntax::ops::*;
 use parser::lexer::{lexC, parseError};
 use parser::builtin::builtinTypeNames;
-use data::name::namesStartingFrom;
+use data::name::new_name_supply;
 
 // fn(A, B) -> fn(C) -> {eval fn(A, B, C)}
 macro_rules! partial_1 {
@@ -2676,7 +2676,7 @@ fn happyError<a: 'static>() -> P<a> {
 }
 
 pub fn parseC(input: InputStream, initialPosition: Position) -> Result<CTranslationUnit<NodeInfo>, ParseError> {
-    execParser(translUnitP(), input, initialPosition, builtinTypeNames(), namesStartingFrom(0))
+    execParser(translUnitP(), input, initialPosition, builtinTypeNames(), new_name_supply())
         .map(|x| x.0)
 }
 

--- a/src/parser/Parser.y
+++ b/src/parser/Parser.y
@@ -2384,7 +2384,7 @@ attribute
   | ident
         {% withNodeInfo($1.clone(), box move |_0| Some(CAttribute($1, vec![], _0))) }
   | const
-        {% withNodeInfo($1, box move |_0| Some(CAttribute(internalIdent("const".to_string()), vec![], _0))) }
+        {% withNodeInfo($1, box move |_0| Some(CAttribute(Ident::internal("const".into()), vec![], _0))) }
   | ident '(' attribute_params ')'
         {% withNodeInfo($1.clone(), box move |_0| Some(CAttribute($1, reverse($3), _0))) }
   | ident '(' ')'

--- a/src/parser/Parser.y
+++ b/src/parser/Parser.y
@@ -1452,7 +1452,7 @@ parameter_typedef_declarator
         {% withNodeInfo($1.clone(), partial_1!(mkVarDeclr, $1)) }
 
   | tyident postfixing_abstract_declarator
-        {% withNodeInfo($1.clone(), box |at| { $2(mkVarDeclr($1, at)) }) }
+        {% withNodeInfo($1.clone(), box move |at| { $2(mkVarDeclr($1, at)) }) }
 
   | clean_typedef_declarator
         { $1 }
@@ -2273,8 +2273,9 @@ constant :: { CConst }
 constant
   : cint        {%
                     withNodeInfo($1.clone(), box move |_0| {
-                        if let CTokILit(_, i) = $1 {
-                            CIntConst(i, _0)
+                        // TODO: I don't get why this is a Fn closure...
+                        if let CTokILit(_, ref i) = $1 {
+                            CIntConst(i.clone(), _0)
                         } else {
                             panic!("irrefutable pattern")
                         }
@@ -2282,8 +2283,8 @@ constant
                 }
   | cchar       {%
                     withNodeInfo($1.clone(), box move |_0| {
-                        if let CTokCLit(_, c) = $1 {
-                            CCharConst(c, _0)
+                        if let CTokCLit(_, ref c) = $1 {
+                            CCharConst(c.clone(), _0)
                         } else {
                             panic!("irrefutable pattern")
                         }
@@ -2291,8 +2292,8 @@ constant
                 }
   | cfloat      {%
                     withNodeInfo($1.clone(), box move |_0| {
-                        if let CTokFLit(_, f) = $1 {
-                            CFloatConst(f, _0)
+                        if let CTokFLit(_, ref f) = $1 {
+                            CFloatConst(f.clone(), _0)
                         } else {
                             panic!("irrefutable pattern")
                         }
@@ -2305,8 +2306,8 @@ string_literal
   : cstr
         {%
             withNodeInfo($1.clone(), box move |_0| {
-                if let CTokSLit(_, s) = $1 {
-                    CStringLiteral(s, _0)
+                if let CTokSLit(_, ref s) = $1 {
+                    CStringLiteral(s.clone(), _0)
                 } else {
                     panic!("irrefutable pattern")
                 }
@@ -2694,4 +2695,4 @@ pub fn expressionP() -> P<CExpr> {
     expression()
 }
 
- }
+}

--- a/src/parser/Parser.y
+++ b/src/parser/Parser.y
@@ -291,7 +291,7 @@ translation_unit
                           thenP(getNewName(), box |n: Name| {
                               thenP(getCurrentPosition(), box move |p: Position| {
                                   let nodeinfo = NodeInfo::new(p.clone(), (p, 0), n);
-                                  __return(CTranslationUnit(decls, nodeinfo))
+                                  returnP(CTranslationUnit(decls, nodeinfo))
                               })
                           })
                       } else {
@@ -345,31 +345,31 @@ external_declaration
 function_definition :: { CFunDef }
 function_definition
   :                            function_declarator compound_statement
-        {% rshift_monad(leaveScope(), withNodeInfo($1.clone(), partial_1!(
+        {% seqP(leaveScope(), withNodeInfo($1.clone(), partial_1!(
             CFunctionDef, vec![], $1, vec![], $2))) }
 
   | attrs                      function_declarator compound_statement
-        {% rshift_monad(leaveScope(), withNodeInfo($1.clone(), partial_1!(
+        {% seqP(leaveScope(), withNodeInfo($1.clone(), partial_1!(
             CFunctionDef, liftCAttrs($1), $2, vec![], $3))) }
 
   | declaration_specifier      function_declarator compound_statement
-        {% rshift_monad(leaveScope(), withNodeInfo($1.clone(), partial_1!(
+        {% seqP(leaveScope(), withNodeInfo($1.clone(), partial_1!(
             CFunctionDef, $1, $2, vec![], $3))) }
 
   | type_specifier             function_declarator compound_statement
-        {% rshift_monad(leaveScope(), withNodeInfo($1.clone(), partial_1!(
+        {% seqP(leaveScope(), withNodeInfo($1.clone(), partial_1!(
             CFunctionDef, $1, $2, vec![], $3))) }
 
   | declaration_qualifier_list function_declarator compound_statement
-        {% rshift_monad(leaveScope(), withNodeInfo($1.clone(), partial_1!(
+        {% seqP(leaveScope(), withNodeInfo($1.clone(), partial_1!(
             CFunctionDef, reverse($1), $2, vec![], $3))) }
 
   | type_qualifier_list        function_declarator compound_statement
-        {% rshift_monad(leaveScope(), withNodeInfo($1.clone(), partial_1!(
+        {% seqP(leaveScope(), withNodeInfo($1.clone(), partial_1!(
             CFunctionDef, liftTypeQuals($1), $2, vec![], $3))) }
 
   | type_qualifier_list  attrs function_declarator compound_statement
-        {% rshift_monad(leaveScope(), withNodeInfo($1.clone(), partial_1!(
+        {% seqP(leaveScope(), withNodeInfo($1.clone(), partial_1!(
             CFunctionDef, __op_addadd(liftTypeQuals($1), liftCAttrs($2)), $3, vec![], $4))) }
 
   -- old function declarators
@@ -402,7 +402,7 @@ function_declarator
   : identifier_declarator
         {%
             let declr = reverseDeclr($1);
-            rshift_monad(enterScope(), rshift_monad(doFuncParamDeclIdent(declr.clone()), __return(declr)))
+            seqP(enterScope(), seqP(doFuncParamDeclIdent(declr.clone()), returnP(declr)))
         }
 
 
@@ -474,23 +474,23 @@ nested_declaration
 nested_function_definition :: { CFunDef }
 nested_function_definition
   : declaration_specifier      function_declarator compound_statement
-        {% rshift_monad(leaveScope(), withNodeInfo($1.clone(), partial_1!(
+        {% seqP(leaveScope(), withNodeInfo($1.clone(), partial_1!(
             CFunctionDef, $1, $2, vec![], $3))) }
 
   | type_specifier             function_declarator compound_statement
-        {% rshift_monad(leaveScope(), withNodeInfo($1.clone(), partial_1!(
+        {% seqP(leaveScope(), withNodeInfo($1.clone(), partial_1!(
             CFunctionDef, $1, $2, vec![], $3))) }
 
   | declaration_qualifier_list function_declarator compound_statement
-        {% rshift_monad(leaveScope(), withNodeInfo($1.clone(), partial_1!(
+        {% seqP(leaveScope(), withNodeInfo($1.clone(), partial_1!(
             CFunctionDef, reverse($1), $2, vec![], $3))) }
 
   | type_qualifier_list   function_declarator compound_statement
-        {% rshift_monad(leaveScope(), withNodeInfo($1.clone(), partial_1!(
+        {% seqP(leaveScope(), withNodeInfo($1.clone(), partial_1!(
             CFunctionDef, liftTypeQuals($1), $2, vec![], $3))) }
 
   | type_qualifier_list   attrs function_declarator compound_statement
-        {% rshift_monad(leaveScope(), withNodeInfo($1.clone(), partial_1!(
+        {% seqP(leaveScope(), withNodeInfo($1.clone(), partial_1!(
             CFunctionDef, __op_addadd(liftTypeQuals($1), liftCAttrs($2)), $3, vec![], $4))) }
 
 
@@ -762,7 +762,7 @@ default_declaring_list
         {%
             let declspecs = reverse($1.clone());
             thenP(withAsmNameAttrs($3, $2), box move |declr: CDeclrR| {
-                rshift_monad(
+                seqP(
                     // TODO: borrow these instead
                     doDeclIdent(declspecs.clone(), declr.clone()),
                     withNodeInfo($1, partial_1!(CDecl, declspecs,
@@ -774,7 +774,7 @@ default_declaring_list
         {%
             let declspecs = liftTypeQuals($1.clone());
             thenP(withAsmNameAttrs($3, $2), box move |declr: CDeclrR| {
-                rshift_monad(
+                seqP(
                     doDeclIdent(declspecs.clone(), declr.clone()),
                     withNodeInfo($1, partial_1!(CDecl, declspecs,
                                                 vec![(Some(reverseDeclr(declr)), $4, None)])))
@@ -785,7 +785,7 @@ default_declaring_list
         {%
             let declspecs = liftTypeQuals($1.clone());
             thenP(withAsmNameAttrs($4, $3), box move |declr: CDeclrR| {
-                rshift_monad(
+                seqP(
                     doDeclIdent(declspecs.clone(), declr.clone()),
                     withNodeInfo($1, partial_1!(CDecl, __op_addadd(declspecs, liftCAttrs($2)),
                                                 vec![(Some(reverseDeclr(declr)), $5, None)])))
@@ -797,7 +797,7 @@ default_declaring_list
         {%
             let declspecs = liftCAttrs($1.clone());
             thenP(withAsmNameAttrs($3, $2), box move |declr: CDeclrR| {
-                rshift_monad(
+                seqP(
                     doDeclIdent(declspecs.clone(), declr.clone()),
                     withNodeInfo($1, partial_1!(CDecl, declspecs,
                                                 vec![(Some(reverseDeclr(declr)), $4, None)])))
@@ -809,7 +809,7 @@ default_declaring_list
             if let CDecl(declspecs, dies, at) = $1 {
                 let (f, s) = $5;
                 thenP(withAsmNameAttrs((f, __op_addadd(s, $3)), $4), box move |declr: CDeclrR| {
-                    rshift_monad(
+                    seqP(
                         doDeclIdent(declspecs.clone(), declr.clone()),
                         withLength(at, partial_1!(CDecl, declspecs,
                                                   __op_concat((Some(reverseDeclr(declr)), $6, None), dies))))
@@ -837,7 +837,7 @@ declaring_list
   : declaration_specifier declarator asm_attrs_opt initializer_opt
         {%
             thenP(withAsmNameAttrs($3, $2), box move |declr: CDeclrR| {
-                rshift_monad(
+                seqP(
                     doDeclIdent($1.clone(), declr.clone()),
                     withNodeInfo($1.clone(), partial_1!(CDecl, $1, vec![(Some(reverseDeclr(declr)), $4, None)])))
             })
@@ -846,7 +846,7 @@ declaring_list
   | type_specifier declarator asm_attrs_opt initializer_opt
         {%
             thenP(withAsmNameAttrs($3, $2), box move |declr: CDeclrR| {
-                rshift_monad(
+                seqP(
                     doDeclIdent($1.clone(), declr.clone()),
                     withNodeInfo($1.clone(), partial_1!(CDecl, $1, vec![(Some(reverseDeclr(declr)), $4, None)])))
             })
@@ -857,9 +857,9 @@ declaring_list
             if let CDecl(declspecs, dies, at) = $1 {
                 let (f, s) = $5;
                 thenP(withAsmNameAttrs((f, __op_addadd(s, $3)), $4), box move |declr: CDeclrR| {
-                    rshift_monad(
+                    seqP(
                         doDeclIdent(declspecs.clone(), declr.clone()),
-                        __return(CDecl(declspecs, __op_concat((Some(reverseDeclr(declr)), $6, None),
+                        returnP(CDecl(declspecs, __op_concat((Some(reverseDeclr(declr)), $6, None),
                                                               dies), at)))
                 })
             } else {
@@ -2430,7 +2430,7 @@ fn withNodeInfo<T: 'static, N: Pos + 'static>(node: N, mkAttrNode: Box<FnBox(Nod
         thenP(getSavedToken(), box move |lastTok| {
             let firstPos = posOf(node);
             let attrs = NodeInfo::new(firstPos, posLenOfTok(lastTok), name);
-            __return(mkAttrNode(attrs))
+            returnP(mkAttrNode(attrs))
         })
     })
 }
@@ -2440,7 +2440,7 @@ fn withLength<a: Clone + 'static>(nodeinfo: NodeInfo, mkAttrNode: Box<FnBox(Node
         let firstPos = nodeinfo.clone().pos();
         let attrs = NodeInfo::new(firstPos, posLenOfTok(lastTok),
                                   nodeinfo.name().unwrap_or_else(|| panic!("nameOfNode")));
-        __return(mkAttrNode(attrs))
+        returnP(mkAttrNode(attrs))
     })
 }
 
@@ -2472,7 +2472,7 @@ fn withAttribute<node: Pos + 'static>(node: node, cattrs: Vec<CAttribute<NodeInf
     thenP(getNewName(), box move |name| {
         let attrs = NodeInfo::with_pos_name(node.posOf(), name);
         let newDeclr = appendDeclrAttrs(cattrs.clone(), mkDeclrNode(attrs));
-        __return(newDeclr)
+        returnP(newDeclr)
     })
 }
 
@@ -2486,7 +2486,7 @@ fn withAttributePF<N: Pos + 'static>(
         let newDeclr: Rc<Box<Fn(CDeclrR) -> CDeclrR>> = Rc::new(box move |_0| {
             appendDeclrAttrs(cattrs.clone(), mkDeclrCtor(attrs.clone(), _0))
         });
-        __return(newDeclr)
+        returnP(newDeclr)
     })
 }
 
@@ -2519,7 +2519,7 @@ fn setAsmName(mAsmName: Option<CStringLiteral<NodeInfo>>,
                   vec!["Duplicate assembler name: ".to_string(), showName(n1), showName(n2)])
         },
         Right(newName) => {
-            __return(CDeclrR(ident, indirections, newName, cattrs, at))
+            returnP(CDeclrR(ident, indirections, newName, cattrs, at))
         },
     }
 }
@@ -2628,7 +2628,7 @@ fn doDeclIdent(declspecs: Vec<CDeclSpec>, CDeclrR(mIdent, _, _, _, _): CDeclrR) 
     };
 
     match mIdent {
-        None => __return(()),
+        None => returnP(()),
         Some(ident) => {
             if any(iypedef, declspecs) { addTypedef(ident) }
             else { shadowTypedef(ident) }
@@ -2656,7 +2656,7 @@ fn doFuncParamDeclIdent(_0: CDeclarator<NodeInfo>) -> P<()> {
             // TODO thread P through this
         },
         _ => {
-            __return(())
+            returnP(())
         },
     }
 }

--- a/src/parser/Parser.y
+++ b/src/parser/Parser.y
@@ -2437,7 +2437,7 @@ fn withNodeInfo<T: 'static, N: Pos + 'static>(node: N, mkAttrNode: Box<FnBox(Nod
 
 fn withLength<a: Clone + 'static>(nodeinfo: NodeInfo, mkAttrNode: Box<FnBox(NodeInfo) -> a>) -> P<a> {
     thenP(getSavedToken(), box move |lastTok| {
-        let firstPos = nodeinfo.clone().pos();
+        let firstPos = nodeinfo.pos().clone();
         let attrs = NodeInfo::new(firstPos, posLenOfTok(lastTok),
                                   nodeinfo.name().unwrap_or_else(|| panic!("nameOfNode")));
         returnP(mkAttrNode(attrs))

--- a/src/parser/Parser.y
+++ b/src/parser/Parser.y
@@ -32,7 +32,6 @@
 {
 
 #[macro_use] use corollary_support::*;
-#[macro_use] use matches;
 use std::boxed::FnBox;
 use std::rc::Rc;
 
@@ -83,80 +82,76 @@ macro_rules! apply_5_1_clone {
         }
     )
 }
-macro_rules! clones {
-    ($($value: ident),*) => {
-        $( let $value = $value.clone(); )*
-    }
-}
-
-// Relevant C99 sections:
-//
-// 6.5 Expressions .1 - .17 and 6.6 (almost literally)
-//  Supported GNU extensions:
-//     - Allow a compound statement as an expression
-//     - Various __builtin_* forms that take type parameters
-//     - `alignof' expression or type
-//     - `__extension__' to suppress warnings about extensions
-//     - Allow taking address of a label with: && label
-//     - Omitting the `then' part of conditional expressions
-//     - complex numbers
-//
-// 6.7 C Declarations .1 -.8
-//  Supported GNU extensions:
-//     - '__thread' thread local storage (6.7.1)
-//
-// 6.8 Statements .1 - .8
-//  Supported GNU extensions:
-//    - case ranges (C99 6.8.1)
-//    - '__label__ ident;' declarations (C99 6.8.2)
-//    - computed gotos (C99 6.8.6)
-//
-// 6.9 Translation unit
-//  Supported GNU extensions:
-//     - allow empty translation_unit
-//     - allow redundant ';'
-//     - allow extension keyword before external declaration
-//     - asm definitions
-//
-//  Since some of the grammar productions are quite difficult to read,
-//  (especially those involved with the decleration syntax) we document them
-//  with an extended syntax that allows a more consise representation:
-//
-//  Ordinary rules
-//
-//   foo      named terminal or non-terminal
-//
-//   'c'      terminal, literal character token
-//
-//   A B      concatenation
-//
-//   A | B    alternation
-//
-//   (A)      grouping
-//
-//  Extended rules
-//
-//   A?       optional, short hand for (A|) or [A]{ 0==A || 1==A }
-//
-//   ...      stands for some part of the grammar omitted for clarity
-//
-//   {A}      represents sequences, 0 or more.
-//
-//   <permute> modifier which states that any permutation of the immediate subterms is valid
-//
-//
-//- TODO ----------------------------------------------------------------------
-//
-//  !* We ignore C11 _Atomic type annotations
-//  !* We ignore the C99 static keyword (see C99 6.7.5.3)
-//  !* We do not distinguish in the AST between incomplete array types and
-//      complete variable length arrays ([ '*' ] means the latter). (see C99 6.7.5.2)
-//  !* The AST doesn't allow recording __attribute__ of unnamed struct field
-//     (see , struct_default_declaring_list, struct_identifier_declarator)
-//  !* see `We're being far to liberal here' (... struct definition within structs)
-//  * Documentation isn't complete and consistent yet.
 
 }
+
+-- Relevant C99 sections:
+--
+-- 6.5 Expressions .1 - .17 and 6.6 (almost literally)
+--  Supported GNU extensions:
+--     - Allow a compound statement as an expression
+--     - Various __builtin_* forms that take type parameters
+--     - `alignof' expression or type
+--     - `__extension__' to suppress warnings about extensions
+--     - Allow taking address of a label with: && label
+--     - Omitting the `then' part of conditional expressions
+--     - complex numbers
+--
+-- 6.7 C Declarations .1 -.8
+--  Supported GNU extensions:
+--     - '__thread' thread local storage (6.7.1)
+--
+-- 6.8 Statements .1 - .8
+--  Supported GNU extensions:
+--    - case ranges (C99 6.8.1)
+--    - '__label__ ident;' declarations (C99 6.8.2)
+--    - computed gotos (C99 6.8.6)
+--
+-- 6.9 Translation unit
+--  Supported GNU extensions:
+--     - allow empty translation_unit
+--     - allow redundant ';'
+--     - allow extension keyword before external declaration
+--     - asm definitions
+--
+--  Since some of the grammar productions are quite difficult to read,
+--  (especially those involved with the decleration syntax) we document them
+--  with an extended syntax that allows a more consise representation:
+--
+--  Ordinary rules
+--
+--   foo      named terminal or non-terminal
+--
+--   'c'      terminal, literal character token
+--
+--   A B      concatenation
+--
+--   A | B    alternation
+--
+--   (A)      grouping
+--
+--  Extended rules
+--
+--   A?       optional, short hand for (A|) or [A]{ 0==A || 1==A }
+--
+--   ...      stands for some part of the grammar omitted for clarity
+--
+--   {A}      represents sequences, 0 or more.
+--
+--   <permute> modifier which states that any permutation of the immediate subterms is valid
+--
+--
+--- TODO ----------------------------------------------------------------------
+--
+--  !* We ignore C11 _Atomic type annotations
+--  !* We ignore the C99 static keyword (see C99 6.7.5.3)
+--  !* We do not distinguish in the AST between incomplete array types and
+--      complete variable length arrays ([ '*' ] means the latter). (see C99 6.7.5.2)
+--  !* The AST doesn't allow recording __attribute__ of unnamed struct field
+--     (see , struct_default_declaring_list, struct_identifier_declarator)
+--  !* see `We're being far to liberal here' (... struct definition within structs)
+--  * Documentation isn't complete and consistent yet.
+
 -- in order to document the parsers, we have to alias them
 %name translation_unit translation_unit
 %name external_declaration external_declaration

--- a/src/parser/builtin.rs
+++ b/src/parser/builtin.rs
@@ -3,12 +3,12 @@
 
 #[macro_use]
 use corollary_support::*;
-use data::ident::*;
+use data::ident::Ident;
 
 // NOTE: These imports are advisory. You probably need to change them to support Rust.
 // use Language::C::Data::Ident;
 // use Ident;
 
 pub fn builtinTypeNames() -> Vec<Ident> {
-    vec![builtinIdent("__builtin_va_list".to_string())]
+    vec![Ident::builtin("__builtin_va_list".into())]
 }

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -17,6 +17,7 @@ use syntax::constants::*;
 use parser::parser_monad::*;
 use parser::tokens::*;
 use std::str::FromStr;
+use std::boxed::FnBox;
 
 // fn(A, B) -> fn(C) -> {eval fn(A, B, C)}
 #[allow(unused_macros)]
@@ -33213,7 +33214,7 @@ const ALEX_ACTIONS: [fn(Position, isize, InputStream) -> P<CToken>; 124] = [
     alex_action_1,
 ];
 
-// Original location: /home/gbr/devel/parser-c/src/parser/Lexer.x, line 279
+// Original location: /home/gbr/devel/parser-c/src/parser/Lexer.x, line 280
 
 
 
@@ -33348,23 +33349,18 @@ pub fn idkwtok(id: String, pos: Position) -> P<CToken> {
         "volatile" => tok(8, box CTokVolatile, pos),
         "__volatile__" => tok(12, box CTokVolatile, pos),
         "while" => tok(5, box CTokWhile, pos),
-        cs => {
-            // TODO
-            let cs = cs.to_owned();
-            let pos = pos.clone();
-
+        _ => {
             thenP(
-                /* let name = */ getNewName(),
+                getNewName(),
                 box move |name| {
-                    let pos = pos.clone();
-                    let len = cs.len() as isize;
-                    let ident = mkIdent(pos.clone(), cs.clone(), name);
+                    let len = id.len() as isize;
+                    let ident = mkIdent(pos.clone(), id, name);
 
                     thenP(isTypeIdent(ident.clone()), box move |tyident| {
                         if tyident {
-                            returnP(CTokTyIdent((pos.clone(), len), ident.clone()))
+                            returnP(CTokTyIdent((pos, len), ident))
                         } else {
-                            returnP(CTokIdent((pos.clone(), len), ident.clone()))
+                            returnP(CTokIdent((pos, len), ident))
                         }
                     })
                 })
@@ -33478,6 +33474,7 @@ pub fn alexInputPrevChar(_: AlexInput) -> char {
 }
 
 pub fn alexGetByte((p, is): AlexInput) -> Option<(Word8, AlexInput)> {
+    // No clone after removing ByteString API
     if inputStreamEmpty(is.clone()) {
         None
     } else {
@@ -33501,7 +33498,6 @@ pub fn lexicalError<a: 'static>() -> P<a> {
     thenP(getPos(), box move |pos: Position| {
         thenP(getInput(), box move |input| {
             let (c, _) = takeChar(input);
-            let pos = pos.clone();
             failP(pos, vec![
                 "Lexical error !".to_string(),
                 format!("The character {} does not fit here.", c),
@@ -33567,8 +33563,8 @@ pub fn lexToken_q(modifyCache: bool) -> P<CToken> {
     })
 }
 
-pub fn lexC<a: 'static>(cont: Box<Fn(CToken) -> P<a>>) -> P<a> {
-    thenP(lexToken(), box move |tok| cont(tok))
+pub fn lexC<a: 'static>(cont: Box<FnBox(CToken) -> P<a>>) -> P<a> {
+    thenP(lexToken(), cont)
 }
 
 

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -33354,7 +33354,7 @@ pub fn idkwtok(id: String, pos: Position) -> P<CToken> {
                 getNewName(),
                 box move |name| {
                     let len = id.len() as isize;
-                    let ident = mkIdent(pos.clone(), id, name);
+                    let ident = Ident::new(pos.clone(), id, name);
 
                     thenP(isTypeIdent(ident.clone()), box move |tyident| {
                         if tyident {

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -33493,7 +33493,7 @@ pub fn lexicalError<a: 'static>() -> P<a> {
 
 pub fn parseError<a: 'static>() -> P<a> {
     thenP(getLastToken(), box move |lastTok: CToken| {
-        failP(posOf(lastTok.clone()), vec![
+        failP(lastTok.clone().into_pos(), vec![
             "Syntax error !".to_string(),
             format!("The symbol `{}' does not fit here.", lastTok)
         ])

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -33362,9 +33362,9 @@ pub fn idkwtok(id: String, pos: Position) -> P<CToken> {
 
                     thenP(isTypeIdent(ident.clone()), box move |tyident| {
                         if tyident {
-                            __return(CTokTyIdent((pos.clone(), len), ident.clone()))
+                            returnP(CTokTyIdent((pos.clone(), len), ident.clone()))
                         } else {
-                            __return(CTokIdent((pos.clone(), len), ident.clone()))
+                            returnP(CTokIdent((pos.clone(), len), ident.clone()))
                         }
                     })
                 })
@@ -33376,7 +33376,7 @@ pub fn ignoreAttribute() -> P<()> {
     pub fn skipTokens(n: isize) -> P<()> {
         thenP(lexToken_q(false), box move |ntok| {
             match ntok {
-                CTokRParen(_) if n == 1 => { __return(()) }
+                CTokRParen(_) if n == 1 => { returnP(()) }
                 CTokRParen(_) => { skipTokens(n - 1) }
                 CTokLParen(_) => { skipTokens(n + 1) },
                 _             => { skipTokens(n) },
@@ -33387,7 +33387,7 @@ pub fn ignoreAttribute() -> P<()> {
 }
 
 pub fn tok(len: isize, tc: Box<Fn(PosLength) -> CToken>, pos: Position) -> P<CToken> {
-    __return(tc((pos, len)))
+    returnP(tc((pos, len)))
 }
 
 pub fn adjustLineDirective(pragmaLen: isize, __str: String, pos: Position) -> Position {
@@ -33440,7 +33440,7 @@ pub fn unescapeMultiChars(cs: String) -> String {
 /// token that ignores the string
 pub fn token_(len: isize, mkTok: Box<Fn(PosLength) -> CToken>, pos: Position,
               _: isize, _: InputStream) -> P<CToken> {
-    __return(mkTok((pos, len)))
+    returnP(mkTok((pos, len)))
 }
 
 /// error token
@@ -33451,7 +33451,7 @@ pub fn token_fail(errmsg: &str, pos: Position, _: isize, _: InputStream) -> P<CT
 /// token that uses the string
 pub fn token<a>(mkTok: Box<Fn(PosLength, a) -> CToken>,
                 fromStr: Box<Fn(String) -> a>, pos: Position, len: isize, __str: InputStream) -> P<CToken> {
-    __return(mkTok((pos, len), fromStr(takeChars_str(len, __str))))
+    returnP(mkTok((pos, len), fromStr(takeChars_str(len, __str))))
 }
 
 /// token that may fail
@@ -33463,7 +33463,7 @@ pub fn token_plus<a>(mkTok: Box<Fn(PosLength, a) -> CToken>,
             failP(pos, vec!["Lexical error ! ".to_string(), err])
         },
         Ok(ok) => {
-            __return(mkTok((pos, len), ok))
+            returnP(mkTok((pos, len), ok))
         },
     }
 }
@@ -33541,24 +33541,26 @@ pub fn lexToken_q(modifyCache: bool) -> P<CToken> {
         thenP(getInput(), box move |inp: InputStream| {
             match alexScan((pos.clone(), inp.clone()), 0) {
                 AlexEOF => {
-                    rshift_monad(handleEofToken(), returnP(CTokEof))
+                    seqP(handleEofToken(), returnP(CTokEof))
                 },
                 AlexError(_inp) => {
                     lexicalError()
                 },
                 AlexSkip((pos_q, inp_q), _len) => {
-                    rshift_monad(setPos(pos_q), rshift_monad(setInput(inp_q), lexToken_q(modifyCache)))
+                    seqP(setPos(pos_q),
+                         seqP(setInput(inp_q),
+                              lexToken_q(modifyCache)))
                 },
                 AlexToken((pos_q, inp_q), len, action) => {
-                    rshift_monad(setPos(pos_q), rshift_monad(
-                        setInput(inp_q),
-                        thenP(action(pos, len, inp), box move |nextTok: CToken| {
-                            if modifyCache {
-                                rshift_monad(setLastToken(nextTok.clone()), returnP(nextTok))
-                            } else {
-                                returnP(nextTok)
-                            }
-                        })))
+                    seqP(setPos(pos_q),
+                         seqP(setInput(inp_q),
+                              thenP(action(pos, len, inp), box move |nextTok: CToken| {
+                                  if modifyCache {
+                                      seqP(setLastToken(nextTok.clone()), returnP(nextTok))
+                                  } else {
+                                      returnP(nextTok)
+                                  }
+                              })))
                 },
             }
         })
@@ -33572,7 +33574,7 @@ pub fn lexC<a: 'static>(cont: Box<Fn(CToken) -> P<a>>) -> P<a> {
 
 fn alex_action_1(pos: Position, len: isize, inp: InputStream) -> P<CToken> {
 
-    rshift_monad(setPos(adjustLineDirective(len, takeChars_str(len, inp), pos)), lexToken_q(false))
+    seqP(setPos(adjustLineDirective(len, takeChars_str(len, inp), pos)), lexToken_q(false))
   
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -23,11 +23,11 @@ pub mod tokens;
 
 use parser::parser_monad::execParser;
 use parser::builtin::*;
-use data::name::*;
+use data::name::new_name_supply;
 use parser::parser_monad::ParseError;
 use data::position::Position;
 use data::input_stream::InputStream;
 
 pub fn execParser_<a: 'static>(parser: P<a>, input: InputStream, pos: Position) -> Result<a, ParseError> {
-    execParser(parser, input, pos, builtinTypeNames(), newNameSupply()).map(|(v, _)| v)
+    execParser(parser, input, pos, builtinTypeNames(), new_name_supply()).map(|(v, _)| v)
 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -16712,7 +16712,7 @@ fn happyReduction_92<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(H
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
                 seqP(
                     // TODO: borrow these instead
-                    doDeclIdent(declspecs.clone(), declr.clone()),
+                    doDeclIdent(&declspecs, declr.clone()),
                     withNodeInfo(happy_var_1, partial_1!(CDecl, declspecs,
                                                 vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
             }) },
@@ -16731,7 +16731,7 @@ fn happyReduction_93<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(H
             let declspecs = liftTypeQuals(happy_var_1.clone());
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
                 seqP(
-                    doDeclIdent(declspecs.clone(), declr.clone()),
+                    doDeclIdent(&declspecs, declr.clone()),
                     withNodeInfo(happy_var_1, partial_1!(CDecl, declspecs,
                                                 vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
             }) },
@@ -16750,7 +16750,7 @@ fn happyReduction_94<T>(HappyStk(HappyAbsSyn94(happy_var_5), Some(box HappyStk(H
             let declspecs = liftTypeQuals(happy_var_1.clone());
             thenP(withAsmNameAttrs(happy_var_4, happy_var_3), box move |declr: CDeclrR| {
                 seqP(
-                    doDeclIdent(declspecs.clone(), declr.clone()),
+                    doDeclIdent(&declspecs, declr.clone()),
                     withNodeInfo(happy_var_1, partial_1!(CDecl, __op_addadd(declspecs, liftCAttrs(happy_var_2)),
                                                 vec![(Some(reverseDeclr(declr)), happy_var_5, None)])))
             }) },
@@ -16769,7 +16769,7 @@ fn happyReduction_95<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(H
             let declspecs = liftCAttrs(happy_var_1.clone());
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
                 seqP(
-                    doDeclIdent(declspecs.clone(), declr.clone()),
+                    doDeclIdent(&declspecs, declr.clone()),
                     withNodeInfo(happy_var_1, partial_1!(CDecl, declspecs,
                                                 vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
             }) },
@@ -16789,7 +16789,7 @@ fn happyReduction_96<T>(HappyStk(HappyAbsSyn94(happy_var_6), Some(box HappyStk(H
                 let (f, s) = happy_var_5;
                 thenP(withAsmNameAttrs((f, __op_addadd(s, happy_var_3)), happy_var_4), box move |declr: CDeclrR| {
                     seqP(
-                        doDeclIdent(declspecs.clone(), declr.clone()),
+                        doDeclIdent(&declspecs, declr.clone()),
                         withLength(at, partial_1!(CDecl, declspecs,
                                                   __op_concat((Some(reverseDeclr(declr)), happy_var_6, None), dies))))
                 })
@@ -16822,7 +16822,7 @@ fn happyReduction_98<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(H
     happyThen({
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
                 seqP(
-                    doDeclIdent(happy_var_1.clone(), declr.clone()),
+                    doDeclIdent(&happy_var_1, declr.clone()),
                     withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
             }) },
               box move |r| happyReturn(HappyAbsSyn32(r)))
@@ -16839,7 +16839,7 @@ fn happyReduction_99<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(H
     happyThen({
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
                 seqP(
-                    doDeclIdent(happy_var_1.clone(), declr.clone()),
+                    doDeclIdent(&happy_var_1, declr.clone()),
                     withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
             }) },
               box move |r| happyReturn(HappyAbsSyn32(r)))
@@ -16858,7 +16858,7 @@ fn happyReduction_100<T>(HappyStk(HappyAbsSyn94(happy_var_6), Some(box HappyStk(
                 let (f, s) = happy_var_5;
                 thenP(withAsmNameAttrs((f, __op_addadd(s, happy_var_3)), happy_var_4), box move |declr: CDeclrR| {
                     seqP(
-                        doDeclIdent(declspecs.clone(), declr.clone()),
+                        doDeclIdent(&declspecs, declr.clone()),
                         returnP(CDecl(declspecs, __op_concat((Some(reverseDeclr(declr)), happy_var_6, None),
                                                               dies), at)))
                 })
@@ -22004,19 +22004,20 @@ fn mkVarDeclr(ident: Ident, ni: NodeInfo) -> CDeclrR {
     CDeclrR(Some(ident), empty(), None, vec![], ni)
 }
 
-fn doDeclIdent(declspecs: Vec<CDeclSpec>, CDeclrR(mIdent, _, _, _, _): CDeclrR) -> P<()> {
-    let iypedef = |_0| {
-        match (_0) {
-            CStorageSpec(CTypedef(_)) => true,
-            _ => false,
-        }
+fn doDeclIdent(declspecs: &[CDeclSpec], CDeclrR(mIdent, _, _, _, _): CDeclrR) -> P<()> {
+    let is_typedef = |declspec: &CDeclSpec| match *declspec {
+        CStorageSpec(CTypedef(_)) => true,
+        _ => false,
     };
 
     match mIdent {
         None => returnP(()),
         Some(ident) => {
-            if any(iypedef, declspecs) { addTypedef(ident) }
-            else { shadowTypedef(ident) }
+            if declspecs.iter().any(is_typedef) {
+                addTypedef(ident)
+            } else {
+                shadowTypedef(ident)
+            }
         },
     }
 }
@@ -22145,7 +22146,7 @@ pub fn expressionP() -> P<CExpr> {
 
 
 // Original location: "<command-line>", line 8
-// Original location: "/tmp/ghc25396_0/ghc_2.h", line 1
+// Original location: "/tmp/ghc1134_0/ghc_2.h", line 1
 
 
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -21517,7 +21517,7 @@ fn happyReduce_480() -> ActionReturn {
 
 refute! {
 fn happyReduction_480<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, box move |_0| Some(CAttribute(internalIdent("const".to_string()), vec![], _0))) },
+    happyThen({ withNodeInfo(happy_var_1, box move |_0| Some(CAttribute(Ident::internal("const".into()), vec![], _0))) },
               box move |r| happyReturn(HappyAbsSyn136(r)))
 }
 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -20,7 +20,7 @@ use data::name::*;
 use syntax::ops::*;
 use parser::lexer::{lexC, parseError};
 use parser::builtin::builtinTypeNames;
-use data::name::namesStartingFrom;
+use data::name::new_name_supply;
 
 // fn(A, B) -> fn(C) -> {eval fn(A, B, C)}
 macro_rules! partial_1 {
@@ -22061,7 +22061,7 @@ fn happyError<a: 'static>() -> P<a> {
 }
 
 pub fn parseC(input: InputStream, initialPosition: Position) -> Result<CTranslationUnit<NodeInfo>, ParseError> {
-    execParser(translUnitP(), input, initialPosition, builtinTypeNames(), namesStartingFrom(0))
+    execParser(translUnitP(), input, initialPosition, builtinTypeNames(), new_name_supply())
         .map(|x| x.0)
 }
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -21822,7 +21822,7 @@ fn withNodeInfo<T: 'static, N: Pos + 'static>(node: N, mkAttrNode: Box<FnBox(Nod
 
 fn withLength<a: Clone + 'static>(nodeinfo: NodeInfo, mkAttrNode: Box<FnBox(NodeInfo) -> a>) -> P<a> {
     thenP(getSavedToken(), box move |lastTok| {
-        let firstPos = nodeinfo.clone().pos();
+        let firstPos = nodeinfo.pos().clone();
         let attrs = NodeInfo::new(firstPos, posLenOfTok(lastTok),
                                   nodeinfo.name().unwrap_or_else(|| panic!("nameOfNode")));
         returnP(mkAttrNode(attrs))

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -15709,21 +15709,15 @@ refute! { fn happyReduction_4<T>(HappyStk(HappyAbsSyn8(happy_var_1), Some(box ha
     happyThen({
                       let decls = reverse(happy_var_1);
                       if decls.len() == 0 {
-                          thenP(getNewName(), box move |n: Name| {
-                              let decls = decls.clone();
+                          thenP(getNewName(), box |n: Name| {
                               thenP(getCurrentPosition(), box move |p: Position| {
-                                  let decls = decls.clone();
-                                  __return(CTranslationUnit::<NodeInfo>(
-                                      decls.clone(),
-                                      (NodeInfo::new(p.clone(), (p.clone(), 0), n.clone())),
-                                  ))
+                                  let nodeinfo = NodeInfo::new(p.clone(), (p, 0), n);
+                                  __return(CTranslationUnit(decls, nodeinfo))
                               })
                           })
                       } else {
                           let d = decls[0].clone();
-                          withNodeInfo(d, box move |_0| {
-                              CTranslationUnit::<NodeInfo>(decls.clone(), _0)
-                          })
+                          withNodeInfo(d, box |_0| CTranslationUnit(decls, _0))
                       } }, (box move |r| { happyReturn(HappyAbsSyn7(r)) }))
 }
 }
@@ -15816,7 +15810,7 @@ fn happyReduce_12() -> ActionReturn {
 
 refute! { fn happyReduction_12<T>(HappyStk(HappyAbsSyn12(happy_var_2), Some(box HappyStk(HappyAbsSyn11(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, vec![], happy_var_1, vec![], happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, vec![], happy_var_1, vec![], happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -15827,7 +15821,7 @@ fn happyReduce_13() -> ActionReturn {
 
 refute! { fn happyReduction_13<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, liftCAttrs(happy_var_1), happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, liftCAttrs(happy_var_1), happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -15838,7 +15832,7 @@ fn happyReduce_14() -> ActionReturn {
 
 refute! { fn happyReduction_14<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, happy_var_1, happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, happy_var_1, happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -15849,7 +15843,7 @@ fn happyReduce_15() -> ActionReturn {
 
 refute! { fn happyReduction_15<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, happy_var_1, happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, happy_var_1, happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -15860,7 +15854,7 @@ fn happyReduce_16() -> ActionReturn {
 
 refute! { fn happyReduction_16<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, reverse(happy_var_1), happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, reverse(happy_var_1), happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -15871,7 +15865,7 @@ fn happyReduce_17() -> ActionReturn {
 
 refute! { fn happyReduction_17<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, liftTypeQuals(happy_var_1), happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, liftTypeQuals(happy_var_1), happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -15882,8 +15876,7 @@ fn happyReduce_18() -> ActionReturn {
 
 refute! { fn happyReduction_18<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn11(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, __op_addadd(liftTypeQuals(happy_var_1),
-                                                  liftCAttrs(happy_var_2)), happy_var_3, vec![], happy_var_4))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)), happy_var_3, vec![], happy_var_4))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -15893,8 +15886,7 @@ fn happyReduce_19() -> ActionReturn {
 }
 
 refute! { fn happyReduction_19<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn33(happy_var_2), Some(box HappyStk(HappyAbsSyn11(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, vec![], happy_var_1, reverse(happy_var_2), happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFunctionDef, vec![], happy_var_1, reverse(happy_var_2), happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -15904,8 +15896,7 @@ fn happyReduce_20() -> ActionReturn {
 }
 
 refute! { fn happyReduction_20<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn33(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, liftCAttrs(happy_var_1), happy_var_2, reverse(happy_var_3), happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+    happyThen({ withNodeInfo(happy_var_2.clone(), partial_1!(CFunctionDef, liftCAttrs(happy_var_1), happy_var_2, reverse(happy_var_3), happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -15915,8 +15906,7 @@ fn happyReduce_21() -> ActionReturn {
 }
 
 refute! { fn happyReduction_21<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn33(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, happy_var_1, happy_var_2, reverse(happy_var_3), happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFunctionDef, happy_var_1, happy_var_2, reverse(happy_var_3), happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -15926,8 +15916,7 @@ fn happyReduce_22() -> ActionReturn {
 }
 
 refute! { fn happyReduction_22<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn33(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, happy_var_1, happy_var_2, reverse(happy_var_3), happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFunctionDef, happy_var_1, happy_var_2, reverse(happy_var_3), happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -15937,8 +15926,7 @@ fn happyReduce_23() -> ActionReturn {
 }
 
 refute! { fn happyReduction_23<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn33(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, reverse(happy_var_1), happy_var_2, reverse(happy_var_3), happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFunctionDef, reverse(happy_var_1), happy_var_2, reverse(happy_var_3), happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -15948,8 +15936,7 @@ fn happyReduce_24() -> ActionReturn {
 }
 
 refute! { fn happyReduction_24<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn33(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, liftTypeQuals(happy_var_1), happy_var_2, reverse(happy_var_3), happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFunctionDef, liftTypeQuals(happy_var_1), happy_var_2, reverse(happy_var_3), happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -15960,8 +15947,7 @@ fn happyReduce_25() -> ActionReturn {
 
 refute! { fn happyReduction_25<T>(HappyStk(HappyAbsSyn12(happy_var_5), Some(box HappyStk(HappyAbsSyn33(happy_var_4), Some(box HappyStk(HappyAbsSyn11(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, __op_addadd(liftTypeQuals(happy_var_1),
-                                                 liftCAttrs(happy_var_2)), happy_var_3, reverse(happy_var_4), happy_var_5)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)), happy_var_3, reverse(happy_var_4), happy_var_5)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -15973,8 +15959,7 @@ fn happyReduce_26() -> ActionReturn {
 refute! { fn happyReduction_26<T>(HappyStk(HappyAbsSyn66(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             let declr = reverseDeclr(happy_var_1);
-            rshift_monad(enterScope(), rshift_monad(doFuncParamDeclIdent(declr.clone()),
-                                                    __return(declr))) }, (box move |r| { happyReturn(HappyAbsSyn11(r)) }))
+            rshift_monad(enterScope(), rshift_monad(doFuncParamDeclIdent(declr.clone()), __return(declr))) }, (box move |r| { happyReturn(HappyAbsSyn11(r)) }))
 }
 }
 
@@ -16056,7 +16041,7 @@ fn happyReduce_33() -> ActionReturn {
 }
 
 refute! { fn happyReduction_33<T>(HappyStk(HappyAbsSyn26(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| { CAsm(happy_var_1, _0) }) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAsm, happy_var_1)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16076,7 +16061,7 @@ fn happyReduce_35() -> ActionReturn {
 }
 
 refute! { fn happyReduction_35<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCase, happy_var_2, box happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCase, happy_var_2, box happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16086,7 +16071,7 @@ fn happyReduce_36() -> ActionReturn {
 }
 
 refute! { fn happyReduction_36<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDefault, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CDefault, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16096,7 +16081,7 @@ fn happyReduce_37() -> ActionReturn {
 }
 
 refute! { fn happyReduction_37<T>(HappyStk(HappyAbsSyn12(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCases, happy_var_2, happy_var_4, box happy_var_6)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCases, happy_var_2, happy_var_4, box happy_var_6)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16106,7 +16091,7 @@ fn happyReduce_38() -> ActionReturn {
 }
 
 refute! { fn happyReduction_38<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn17(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCompound, vec![], reverse(happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCompound, vec![], reverse(happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16116,7 +16101,7 @@ fn happyReduce_39() -> ActionReturn {
 }
 
 refute! { fn happyReduction_39<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn17(happy_var_4), Some(box HappyStk(HappyAbsSyn21(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCompound, reverse(happy_var_3), reverse(happy_var_4))) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCompound, reverse(happy_var_3), reverse(happy_var_4))) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16230,7 +16215,7 @@ fn happyReduce_49() -> ActionReturn {
 
 refute! { fn happyReduction_49<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, happy_var_1, happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, happy_var_1, happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -16241,7 +16226,7 @@ fn happyReduce_50() -> ActionReturn {
 
 refute! { fn happyReduction_50<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, happy_var_1, happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, happy_var_1, happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -16252,7 +16237,7 @@ fn happyReduce_51() -> ActionReturn {
 
 refute! { fn happyReduction_51<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, reverse(happy_var_1), happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, reverse(happy_var_1), happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -16263,7 +16248,7 @@ fn happyReduce_52() -> ActionReturn {
 
 refute! { fn happyReduction_52<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, liftTypeQuals(happy_var_1), happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, liftTypeQuals(happy_var_1), happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -16274,8 +16259,7 @@ fn happyReduce_53() -> ActionReturn {
 
 refute! { fn happyReduction_53<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn11(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef::<NodeInfo>, __op_addadd(liftTypeQuals(happy_var_1),
-                                                  liftCAttrs(happy_var_2)), happy_var_3, vec![], happy_var_4))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)), happy_var_3, vec![], happy_var_4))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
 }
 }
 
@@ -16307,7 +16291,7 @@ fn happyReduce_56() -> ActionReturn {
 }
 
 refute! { fn happyReduction_56<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CExpr, None)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CExpr, None)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16327,7 +16311,7 @@ fn happyReduce_58() -> ActionReturn {
 }
 
 refute! { fn happyReduction_58<T>(HappyStk(HappyAbsSyn12(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CIf, happy_var_3, box happy_var_5, None)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CIf, happy_var_3, box happy_var_5, None)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16337,7 +16321,7 @@ fn happyReduce_59() -> ActionReturn {
 }
 
 refute! { fn happyReduction_59<T>(HappyStk(HappyAbsSyn12(happy_var_7), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn12(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CIf, happy_var_3, box happy_var_5, Some(box happy_var_7))) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CIf, happy_var_3, box happy_var_5, Some(box happy_var_7))) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16347,7 +16331,7 @@ fn happyReduce_60() -> ActionReturn {
 }
 
 refute! { fn happyReduction_60<T>(HappyStk(HappyAbsSyn12(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CSwitch, happy_var_3, box happy_var_5)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CSwitch, happy_var_3, box happy_var_5)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16357,7 +16341,7 @@ fn happyReduce_61() -> ActionReturn {
 }
 
 refute! { fn happyReduction_61<T>(HappyStk(HappyAbsSyn12(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CWhile, happy_var_3, box happy_var_5, false)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CWhile, happy_var_3, box happy_var_5, false)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16367,7 +16351,7 @@ fn happyReduce_62() -> ActionReturn {
 }
 
 refute! { fn happyReduction_62<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn12(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CWhile, happy_var_5, box happy_var_2, true)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CWhile, happy_var_5, box happy_var_2, true)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16377,7 +16361,7 @@ fn happyReduce_63() -> ActionReturn {
 }
 
 refute! { fn happyReduction_63<T>(HappyStk(HappyAbsSyn12(happy_var_9), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_7), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFor, Left(happy_var_3), happy_var_5, happy_var_7, box happy_var_9)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CFor, Left(happy_var_3), happy_var_5, happy_var_7, box happy_var_9)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16387,7 +16371,7 @@ fn happyReduce_64() -> ActionReturn {
 }
 
 refute! { fn happyReduction_64<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn12(happy_var_9), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_7), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_5), Some(box HappyStk(HappyAbsSyn32(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFor, Right(happy_var_4), happy_var_5, happy_var_7, box happy_var_9)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CFor, Right(happy_var_4), happy_var_5, happy_var_7, box happy_var_9)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16397,7 +16381,7 @@ fn happyReduce_65() -> ActionReturn {
 }
 
 refute! { fn happyReduction_65<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CGoto, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CGoto, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16407,7 +16391,7 @@ fn happyReduce_66() -> ActionReturn {
 }
 
 refute! { fn happyReduction_66<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CGotoPtr, happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CGotoPtr, happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16417,7 +16401,7 @@ fn happyReduce_67() -> ActionReturn {
 }
 
 refute! { fn happyReduction_67<T>(HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCont)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCont)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16427,7 +16411,7 @@ fn happyReduce_68() -> ActionReturn {
 }
 
 refute! { fn happyReduction_68<T>(HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBreak)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CBreak)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16437,7 +16421,7 @@ fn happyReduce_69() -> ActionReturn {
 }
 
 refute! { fn happyReduction_69<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CReturn, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CReturn, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
 }
 }
 
@@ -16447,7 +16431,7 @@ fn happyReduce_70() -> ActionReturn {
 }
 
 refute! { fn happyReduction_70<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn27(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAssemblyStatement::<NodeInfo>, happy_var_2, happy_var_4, vec![], vec![], vec![])) }, (box move |r| { happyReturn(HappyAbsSyn26(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyStatement, happy_var_2, happy_var_4, vec![], vec![], vec![])) }, (box move |r| { happyReturn(HappyAbsSyn26(r)) }))
 }
 }
 
@@ -16457,7 +16441,7 @@ fn happyReduce_71() -> ActionReturn {
 }
 
 refute! { fn happyReduction_71<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn28(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn27(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAssemblyStatement::<NodeInfo>, happy_var_2, happy_var_4, happy_var_6, vec![], vec![])) }, (box move |r| { happyReturn(HappyAbsSyn26(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyStatement, happy_var_2, happy_var_4, happy_var_6, vec![], vec![])) }, (box move |r| { happyReturn(HappyAbsSyn26(r)) }))
 }
 }
 
@@ -16467,7 +16451,7 @@ fn happyReduce_72() -> ActionReturn {
 }
 
 refute! { fn happyReduction_72<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn28(happy_var_8), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn28(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn27(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAssemblyStatement::<NodeInfo>, happy_var_2, happy_var_4, happy_var_6, happy_var_8, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn26(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyStatement, happy_var_2, happy_var_4, happy_var_6, happy_var_8, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn26(r)) }))
 }
 }
 
@@ -16477,7 +16461,7 @@ fn happyReduce_73() -> ActionReturn {
 }
 
 refute! { fn happyReduction_73<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn31(happy_var_10), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn28(happy_var_8), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn28(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn27(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAssemblyStatement::<NodeInfo>, happy_var_2, happy_var_4, happy_var_6, happy_var_8, reverse(happy_var_10))) }, (box move |r| { happyReturn(HappyAbsSyn26(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyStatement, happy_var_2, happy_var_4, happy_var_6, happy_var_8, reverse(happy_var_10))) }, (box move |r| { happyReturn(HappyAbsSyn26(r)) }))
 }
 }
 
@@ -16557,7 +16541,7 @@ fn happyReduce_80() -> ActionReturn {
 }
 
 refute! { fn happyReduction_80<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAssemblyOperand::<NodeInfo>, None, happy_var_1, happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn30(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAssemblyOperand, None, happy_var_1, happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn30(r)) }))
 }
 }
 
@@ -16567,7 +16551,7 @@ fn happyReduce_81() -> ActionReturn {
 }
 
 refute! { fn happyReduction_81<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(CTokIdent(_, happy_var_2)), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAssemblyOperand::<NodeInfo>, Some(happy_var_2), happy_var_4, happy_var_6)) }, (box move |r| { happyReturn(HappyAbsSyn30(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyOperand, Some(happy_var_2), happy_var_4, happy_var_6)) }, (box move |r| { happyReturn(HappyAbsSyn30(r)) }))
 }
 }
 
@@ -16577,7 +16561,7 @@ fn happyReduce_82() -> ActionReturn {
 }
 
 refute! { fn happyReduction_82<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_2)), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAssemblyOperand::<NodeInfo>, Some(happy_var_2), happy_var_4, happy_var_6)) }, (box move |r| { happyReturn(HappyAbsSyn30(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyOperand, Some(happy_var_2), happy_var_4, happy_var_6)) }, (box move |r| { happyReturn(HappyAbsSyn30(r)) }))
 }
 }
 
@@ -16633,10 +16617,9 @@ fn happyReduce_87() -> ActionReturn {
 refute! { fn happyReduction_87<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             if let CDecl(declspecs, dies, at) = happy_var_1 {
-                // TODO clones
-                withLength(at, box move |_0| { CDecl(declspecs.clone(), List::reverse(dies.clone()), _0) })
+                withLength(at, partial_1!(CDecl, declspecs, List::reverse(dies)))
             } else {
-                panic!("irrefutable pattern");
+                panic!("irrefutable pattern")
             } }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
 }
 }
@@ -16649,10 +16632,9 @@ fn happyReduce_88() -> ActionReturn {
 refute! { fn happyReduction_88<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             if let CDecl(declspecs, dies, at) = happy_var_1 {
-                // TODO clones
-                withLength(at, box move |_0| { CDecl(declspecs.clone(), List::reverse(dies.clone()), _0) })
+                withLength(at, partial_1!(CDecl, declspecs, List::reverse(dies)))
             } else {
-                panic!("irrefutable pattern");
+                panic!("irrefutable pattern")
             } }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
 }
 }
@@ -16663,7 +16645,7 @@ fn happyReduce_89() -> ActionReturn {
 }
 
 refute! { fn happyReduction_89<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CStaticAssert, happy_var_3, happy_var_5)) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CStaticAssert, happy_var_3, happy_var_5)) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
 }
 }
 
@@ -16699,11 +16681,11 @@ refute! { fn happyReduction_92<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box 
     happyThen({
             let declspecs = reverse(happy_var_1.clone());
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
-                clones!(happy_var_4, happy_var_1, declspecs);
-                // TODO: the return value here should not be ignored!
-                doDeclIdent(declspecs.clone(), declr.clone());
-                withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, declspecs.clone(),
-                                                    vec![(Some(reverseDeclr(declr.clone())), happy_var_4, None)]))
+                rshift_monad(
+                    // TODO: borrow these instead
+                    doDeclIdent(declspecs.clone(), declr.clone()),
+                    withNodeInfo(happy_var_1, partial_1!(CDecl, declspecs,
+                                                vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
             }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
 }
 }
@@ -16717,11 +16699,10 @@ refute! { fn happyReduction_93<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box 
     happyThen({
             let declspecs = liftTypeQuals(happy_var_1.clone());
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
-                clones!(happy_var_4, happy_var_1, declspecs);
-                // TODO: the return value here should not be ignored!
-                doDeclIdent(declspecs.clone(), declr.clone());
-                withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, declspecs.clone(),
-                                                    vec![(Some(reverseDeclr(declr.clone())), happy_var_4, None)]))
+                rshift_monad(
+                    doDeclIdent(declspecs.clone(), declr.clone()),
+                    withNodeInfo(happy_var_1, partial_1!(CDecl, declspecs,
+                                                vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
             }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
 }
 }
@@ -16735,11 +16716,10 @@ refute! { fn happyReduction_94<T>(HappyStk(HappyAbsSyn94(happy_var_5), Some(box 
     happyThen({
             let declspecs = liftTypeQuals(happy_var_1.clone());
             thenP(withAsmNameAttrs(happy_var_4, happy_var_3), box move |declr: CDeclrR| {
-                clones!(happy_var_2, happy_var_5, declspecs);
-                // TODO: the return value here should not be ignored!
-                doDeclIdent(declspecs.clone(), declr.clone());
-                withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, __op_addadd(declspecs.clone(), liftCAttrs(happy_var_2)),
-                                                    vec![(Some(reverseDeclr(declr.clone())), happy_var_5, None)]))
+                rshift_monad(
+                    doDeclIdent(declspecs.clone(), declr.clone()),
+                    withNodeInfo(happy_var_1, partial_1!(CDecl, __op_addadd(declspecs, liftCAttrs(happy_var_2)),
+                                                vec![(Some(reverseDeclr(declr)), happy_var_5, None)])))
             }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
 }
 }
@@ -16753,11 +16733,10 @@ refute! { fn happyReduction_95<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box 
     happyThen({
             let declspecs = liftCAttrs(happy_var_1.clone());
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
-                clones!(happy_var_4, declspecs);
-                // TODO: the return value here should not be ignored!
-                doDeclIdent(declspecs.clone(), declr.clone());
-                withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, declspecs.clone(),
-                                                    vec![(Some(reverseDeclr(declr.clone())), happy_var_4, None)]))
+                rshift_monad(
+                    doDeclIdent(declspecs.clone(), declr.clone()),
+                    withNodeInfo(happy_var_1, partial_1!(CDecl, declspecs,
+                                                vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
             }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
 }
 }
@@ -16770,17 +16749,15 @@ fn happyReduce_96() -> ActionReturn {
 refute! { fn happyReduction_96<T>(HappyStk(HappyAbsSyn94(happy_var_6), Some(box HappyStk(HappyAbsSyn35(happy_var_5), Some(box HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             if let CDecl(declspecs, dies, at) = happy_var_1 {
-                clones!(happy_var_5);
-                thenP(withAsmNameAttrs((fst(happy_var_5.clone()), __op_addadd(snd(happy_var_5), happy_var_3)), happy_var_4), box move |declr: CDeclrR| {
-                    clones!(happy_var_6, declspecs, dies, at);
-                    // TODO: the return value here should not be ignored!
-                    doDeclIdent(declspecs.clone(), declr.clone());
-                    withLength(at.clone(), box move |_0| { CDecl(
-                        declspecs.clone(), __op_concat((Some(reverseDeclr(declr.clone())), happy_var_6.clone(), None),
-                                                       dies.clone()), _0) })
+                let (f, s) = happy_var_5;
+                thenP(withAsmNameAttrs((f, __op_addadd(s, happy_var_3)), happy_var_4), box move |declr: CDeclrR| {
+                    rshift_monad(
+                        doDeclIdent(declspecs.clone(), declr.clone()),
+                        withLength(at, partial_1!(CDecl, declspecs,
+                                                  __op_concat((Some(reverseDeclr(declr)), happy_var_6, None), dies))))
                 })
             } else {
-                panic!("irrefutable pattern");
+                panic!("irrefutable pattern")
             } }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
 }
 }
@@ -16805,10 +16782,9 @@ fn happyReduce_98() -> ActionReturn {
 refute! { fn happyReduction_98<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
-                clones!(happy_var_1, happy_var_4);
-                // TODO: the return value here should not be ignored!
-                doDeclIdent(happy_var_1.clone(), declr.clone());
-                withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![(Some(reverseDeclr(declr.clone())), happy_var_4, None)]))
+                rshift_monad(
+                    doDeclIdent(happy_var_1.clone(), declr.clone()),
+                    withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
             }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
 }
 }
@@ -16821,10 +16797,9 @@ fn happyReduce_99() -> ActionReturn {
 refute! { fn happyReduction_99<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
-                clones!(happy_var_1, happy_var_4);
-                // TODO: the return value here should not be ignored!
-                doDeclIdent(happy_var_1.clone(), declr.clone());
-                withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![(Some(reverseDeclr(declr.clone())), happy_var_4, None)]))
+                rshift_monad(
+                    doDeclIdent(happy_var_1.clone(), declr.clone()),
+                    withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
             }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
 }
 }
@@ -16837,14 +16812,15 @@ fn happyReduce_100() -> ActionReturn {
 refute! { fn happyReduction_100<T>(HappyStk(HappyAbsSyn94(happy_var_6), Some(box HappyStk(HappyAbsSyn35(happy_var_5), Some(box HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             if let CDecl(declspecs, dies, at) = happy_var_1 {
-                thenP(withAsmNameAttrs((fst(happy_var_5.clone()), __op_addadd(snd(happy_var_5), happy_var_3)), happy_var_4), box move |declr: CDeclrR| {
-                    // TODO: the return value here should not be ignored!
-                    doDeclIdent(declspecs.clone(), declr.clone());
-                    __return(CDecl(declspecs.clone(), __op_concat((Some(reverseDeclr(declr)),
-                                                                   happy_var_6.clone(), None), dies.clone()), at.clone()))
+                let (f, s) = happy_var_5;
+                thenP(withAsmNameAttrs((f, __op_addadd(s, happy_var_3)), happy_var_4), box move |declr: CDeclrR| {
+                    rshift_monad(
+                        doDeclIdent(declspecs.clone(), declr.clone()),
+                        __return(CDecl(declspecs, __op_concat((Some(reverseDeclr(declr)), happy_var_6, None),
+                                                              dies), at)))
                 })
             } else {
-                panic!("irrefutable pattern");
+                panic!("irrefutable pattern")
             } }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
 }
 }
@@ -17047,7 +17023,7 @@ fn happyReduce_117() -> ActionReturn {
 }
 
 refute! { fn happyReduction_117<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CTypedef)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CTypedef)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
 }
 }
 
@@ -17057,7 +17033,7 @@ fn happyReduce_118() -> ActionReturn {
 }
 
 refute! { fn happyReduction_118<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CExtern)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CExtern)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
 }
 }
 
@@ -17067,7 +17043,7 @@ fn happyReduce_119() -> ActionReturn {
 }
 
 refute! { fn happyReduction_119<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CStatic)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CStatic)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
 }
 }
 
@@ -17077,7 +17053,7 @@ fn happyReduce_120() -> ActionReturn {
 }
 
 refute! { fn happyReduction_120<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAuto)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAuto)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
 }
 }
 
@@ -17087,7 +17063,7 @@ fn happyReduce_121() -> ActionReturn {
 }
 
 refute! { fn happyReduction_121<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CRegister)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CRegister)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
 }
 }
 
@@ -17097,7 +17073,7 @@ fn happyReduce_122() -> ActionReturn {
 }
 
 refute! { fn happyReduction_122<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CThread)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CThread)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
 }
 }
 
@@ -17107,7 +17083,7 @@ fn happyReduce_123() -> ActionReturn {
 }
 
 refute! { fn happyReduction_123<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CInlineQual)) }, (box move |r| { happyReturn(HappyAbsSyn42(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CInlineQual)) }, (box move |r| { happyReturn(HappyAbsSyn42(r)) }))
 }
 }
 
@@ -17117,7 +17093,7 @@ fn happyReduce_124() -> ActionReturn {
 }
 
 refute! { fn happyReduction_124<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CNoreturnQual)) }, (box move |r| { happyReturn(HappyAbsSyn42(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CNoreturnQual)) }, (box move |r| { happyReturn(HappyAbsSyn42(r)) }))
 }
 }
 
@@ -17127,7 +17103,7 @@ fn happyReduce_125() -> ActionReturn {
 }
 
 refute! { fn happyReduction_125<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAlignAsType, happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn43(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAlignAsType, happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn43(r)) }))
 }
 }
 
@@ -17137,7 +17113,7 @@ fn happyReduce_126() -> ActionReturn {
 }
 
 refute! { fn happyReduction_126<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAlignAsExpr, happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn43(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAlignAsExpr, happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn43(r)) }))
 }
 }
 
@@ -17183,7 +17159,7 @@ fn happyReduce_130() -> ActionReturn {
 }
 
 refute! { fn happyReduction_130<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CVoidType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CVoidType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
 }
 }
 
@@ -17193,7 +17169,7 @@ fn happyReduce_131() -> ActionReturn {
 }
 
 refute! { fn happyReduction_131<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCharType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCharType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
 }
 }
 
@@ -17203,7 +17179,7 @@ fn happyReduce_132() -> ActionReturn {
 }
 
 refute! { fn happyReduction_132<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CShortType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CShortType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
 }
 }
 
@@ -17213,7 +17189,7 @@ fn happyReduce_133() -> ActionReturn {
 }
 
 refute! { fn happyReduction_133<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CIntType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CIntType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
 }
 }
 
@@ -17223,7 +17199,7 @@ fn happyReduce_134() -> ActionReturn {
 }
 
 refute! { fn happyReduction_134<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CLongType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CLongType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
 }
 }
 
@@ -17233,7 +17209,7 @@ fn happyReduce_135() -> ActionReturn {
 }
 
 refute! { fn happyReduction_135<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFloatType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CFloatType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
 }
 }
 
@@ -17243,7 +17219,7 @@ fn happyReduce_136() -> ActionReturn {
 }
 
 refute! { fn happyReduction_136<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDoubleType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CDoubleType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
 }
 }
 
@@ -17253,7 +17229,7 @@ fn happyReduce_137() -> ActionReturn {
 }
 
 refute! { fn happyReduction_137<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CSignedType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CSignedType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
 }
 }
 
@@ -17263,7 +17239,7 @@ fn happyReduce_138() -> ActionReturn {
 }
 
 refute! { fn happyReduction_138<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CUnsigType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CUnsigType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
 }
 }
 
@@ -17273,7 +17249,7 @@ fn happyReduce_139() -> ActionReturn {
 }
 
 refute! { fn happyReduction_139<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBoolType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CBoolType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
 }
 }
 
@@ -17283,7 +17259,7 @@ fn happyReduce_140() -> ActionReturn {
 }
 
 refute! { fn happyReduction_140<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CComplexType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CComplexType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
 }
 }
 
@@ -17293,7 +17269,7 @@ fn happyReduce_141() -> ActionReturn {
 }
 
 refute! { fn happyReduction_141<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CInt128Type)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CInt128Type)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
 }
 }
 
@@ -17579,7 +17555,7 @@ fn happyReduce_165() -> ActionReturn {
 }
 
 refute! { fn happyReduction_165<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_2)), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| { snoc(happy_var_1, CTypeSpec(CTypeDef(happy_var_2, at))) }) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| snoc(happy_var_1, CTypeSpec(CTypeDef(happy_var_2, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
 }
 }
 
@@ -17589,7 +17565,7 @@ fn happyReduce_166() -> ActionReturn {
 }
 
 refute! { fn happyReduction_166<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| { snoc(happy_var_1, CTypeSpec(CTypeOfExpr(happy_var_4, at))) }) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+    happyThen({ withNodeInfo(happy_var_2, box |at| snoc(happy_var_1, CTypeSpec(CTypeOfExpr(happy_var_4, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
 }
 }
 
@@ -17599,7 +17575,7 @@ fn happyReduce_167() -> ActionReturn {
 }
 
 refute! { fn happyReduction_167<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| { snoc(happy_var_1, CTypeSpec(CTypeOfType(happy_var_4, at))) }) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+    happyThen({ withNodeInfo(happy_var_2, box |at| snoc(happy_var_1, CTypeSpec(CTypeOfType(happy_var_4, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
 }
 }
 
@@ -17633,7 +17609,7 @@ fn happyReduce_170() -> ActionReturn {
 }
 
 refute! { fn happyReduction_170<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_1)), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box |at| { singleton(CTypeSpec(CTypeDef(happy_var_1, at))) }) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), box |at| singleton(CTypeSpec(CTypeDef(happy_var_1, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
 }
 }
 
@@ -17643,7 +17619,7 @@ fn happyReduce_171() -> ActionReturn {
 }
 
 refute! { fn happyReduction_171<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box |at| { singleton(CTypeSpec(CTypeOfExpr(happy_var_3, at))) }) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, box |at| singleton(CTypeSpec(CTypeOfExpr(happy_var_3, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
 }
 }
 
@@ -17653,7 +17629,7 @@ fn happyReduce_172() -> ActionReturn {
 }
 
 refute! { fn happyReduction_172<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box |at| { singleton(CTypeSpec(CTypeOfType(happy_var_3, at))) }) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, box |at| singleton(CTypeSpec(CTypeOfType(happy_var_3, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
 }
 }
 
@@ -17663,7 +17639,7 @@ fn happyReduce_173() -> ActionReturn {
 }
 
 refute! { fn happyReduction_173<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_2)), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| { snoc(rmap(CTypeQual, happy_var_1), CTypeSpec(CTypeDef(happy_var_2, at))) }) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| snoc(rmap(CTypeQual, happy_var_1), CTypeSpec(CTypeDef(happy_var_2, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
 }
 }
 
@@ -17673,7 +17649,7 @@ fn happyReduce_174() -> ActionReturn {
 }
 
 refute! { fn happyReduction_174<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| { snoc(rmap(CTypeQual, happy_var_1), CTypeSpec(CTypeOfExpr(happy_var_4, at))) }) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+    happyThen({ withNodeInfo(happy_var_2, box |at| snoc(rmap(CTypeQual, happy_var_1), CTypeSpec(CTypeOfExpr(happy_var_4, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
 }
 }
 
@@ -17683,7 +17659,7 @@ fn happyReduce_175() -> ActionReturn {
 }
 
 refute! { fn happyReduction_175<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| { snoc(rmap(CTypeQual, happy_var_1), CTypeSpec(CTypeOfType(happy_var_4, at))) }) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+    happyThen({ withNodeInfo(happy_var_2, box |at| snoc(rmap(CTypeQual, happy_var_1), CTypeSpec(CTypeOfType(happy_var_4, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
 }
 }
 
@@ -17693,7 +17669,7 @@ fn happyReduce_176() -> ActionReturn {
 }
 
 refute! { fn happyReduction_176<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_2)), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| { snoc(reverseList(liftCAttrs(happy_var_1)), CTypeSpec(CTypeDef(happy_var_2, at))) }) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| snoc(reverseList(liftCAttrs(happy_var_1)), CTypeSpec(CTypeDef(happy_var_2, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
 }
 }
 
@@ -17703,7 +17679,7 @@ fn happyReduce_177() -> ActionReturn {
 }
 
 refute! { fn happyReduction_177<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box |at| { snoc(reverseList(liftCAttrs(happy_var_1)), CTypeSpec(CTypeOfExpr(happy_var_4, at))) }) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), box |at| snoc(reverseList(liftCAttrs(happy_var_1)), CTypeSpec(CTypeOfExpr(happy_var_4, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
 }
 }
 
@@ -17713,7 +17689,7 @@ fn happyReduce_178() -> ActionReturn {
 }
 
 refute! { fn happyReduction_178<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_2), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| { snoc(reverseList(liftCAttrs(happy_var_1)), CTypeSpec(CTypeOfType(happy_var_4, at))) }) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+    happyThen({ withNodeInfo(happy_var_2, box |at| snoc(reverseList(liftCAttrs(happy_var_1)), CTypeSpec(CTypeOfType(happy_var_4, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
 }
 }
 
@@ -17723,8 +17699,8 @@ fn happyReduce_179() -> ActionReturn {
 }
 
 refute! { fn happyReduction_179<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_3)), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_3.clone(), box |at| { snoc(rappend(rmap(CTypeQual, happy_var_1), liftCAttrs(happy_var_2)),
-                                                  CTypeSpec(CTypeDef(happy_var_3, at))) }) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+    happyThen({ withNodeInfo(happy_var_3.clone(), box |at| snoc(rappend(rmap(CTypeQual, happy_var_1), liftCAttrs(happy_var_2)),
+                                                  CTypeSpec(CTypeDef(happy_var_3, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
 }
 }
 
@@ -17734,8 +17710,8 @@ fn happyReduce_180() -> ActionReturn {
 }
 
 refute! { fn happyReduction_180<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_3.clone(), box |at| { snoc(rappend(rmap(CTypeQual, happy_var_1), liftCAttrs(happy_var_2)),
-                                                    CTypeSpec(CTypeOfExpr(happy_var_5, at))) }) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+    happyThen({ withNodeInfo(happy_var_3, box |at| snoc(rappend(rmap(CTypeQual, happy_var_1), liftCAttrs(happy_var_2)),
+                                          CTypeSpec(CTypeOfExpr(happy_var_5, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
 }
 }
 
@@ -17745,8 +17721,8 @@ fn happyReduce_181() -> ActionReturn {
 }
 
 refute! { fn happyReduction_181<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_3.clone(), box |at| { snoc(rappend(rmap(CTypeQual, happy_var_1), liftCAttrs(happy_var_2)),
-                                                    CTypeSpec(CTypeOfType(happy_var_5, at))) }) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+    happyThen({ withNodeInfo(happy_var_3, box |at| snoc(rappend(rmap(CTypeQual, happy_var_1), liftCAttrs(happy_var_2)),
+                                          CTypeSpec(CTypeOfType(happy_var_5, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
 }
 }
 
@@ -17800,7 +17776,7 @@ fn happyReduce_186() -> ActionReturn {
 }
 
 refute! { fn happyReduction_186<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn33(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn54(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CStructureUnion::<NodeInfo>, unL(happy_var_1), Some(happy_var_3), Some(reverse(happy_var_5)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn53(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CStructureUnion, unL(happy_var_1), Some(happy_var_3), Some(reverse(happy_var_5)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn53(r)) }))
 }
 }
 
@@ -17810,7 +17786,7 @@ fn happyReduce_187() -> ActionReturn {
 }
 
 refute! { fn happyReduction_187<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn33(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn54(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CStructureUnion::<NodeInfo>, unL(happy_var_1), None,     Some(reverse(happy_var_4)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn53(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CStructureUnion, unL(happy_var_1), None,     Some(reverse(happy_var_4)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn53(r)) }))
 }
 }
 
@@ -17820,7 +17796,7 @@ fn happyReduce_188() -> ActionReturn {
 }
 
 refute! { fn happyReduction_188<T>(HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn54(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CStructureUnion::<NodeInfo>, unL(happy_var_1), Some(happy_var_3), None,              happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn53(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CStructureUnion, unL(happy_var_1), Some(happy_var_3), None,              happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn53(r)) }))
 }
 }
 
@@ -17935,8 +17911,8 @@ fn happyReduce_197() -> ActionReturn {
 refute! { fn happyReduction_197<T>(HappyStk(HappyAbsSyn59(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             withNodeInfo(happy_var_1.clone(), match happy_var_3 {
-                (d, s) => box move |_0| { CDecl(__op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)),
-                                                vec![(d.clone(), None, s.clone())], _0) }
+                (d, s) => partial_1!(CDecl, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)),
+                                     vec![(d, None, s)])
             }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
 }
 }
@@ -17949,7 +17925,7 @@ fn happyReduce_198() -> ActionReturn {
 refute! { fn happyReduction_198<T>(HappyStk(HappyAbsSyn59(happy_var_2), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             withNodeInfo(happy_var_1.clone(), match happy_var_2 {
-                (d, s) => box move |_0| { CDecl(liftCAttrs(happy_var_1), vec![(d.clone(), None, s.clone())], _0) }
+                (d, s) => partial_1!(CDecl, liftCAttrs(happy_var_1), vec![(d, None, s)]),
             }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
 }
 }
@@ -17970,7 +17946,7 @@ refute! { fn happyReduction_199(HappyStk(HappyAbsSyn59(happy_var_4), Some(box Ha
                     },
                 }
             } else {
-                panic!("irrefutable pattern");
+                panic!("irrefutable pattern")
             }), Some(box happyRest))
 }
 }
@@ -17984,10 +17960,10 @@ refute! { fn happyReduction_200<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(bo
     happyThen({
             withNodeInfo(happy_var_1.clone(), match happy_var_2 {
                 (Some(d), s) => {
-                    box move |_0| { CDecl(happy_var_1, vec![(Some(appendObjAttrs(happy_var_3, d.clone())), None, s.clone())], _0) }
+                    partial_1!(CDecl, happy_var_1, vec![(Some(appendObjAttrs(happy_var_3, d)), None, s)])
                 },
                 (None, s) => {
-                    box move |_0| { CDecl(happy_var_1, vec![(None, None, s.clone())], _0) }
+                    partial_1!(CDecl, happy_var_1, vec![(None, None, s)])
                 },
             }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
 }
@@ -18105,13 +18081,9 @@ fn happyReduce_209() -> ActionReturn {
 fn happyReduction_209(happy_x_2: HappyAbsSyn, happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_2, happy_x_1) {
         (HappyAbsSyn132(happy_var_2), HappyAbsSyn59(happy_var_1)) => HappyAbsSyn59(match happy_var_1 {
-                (None, expr) => {
-                    (None, expr)
-                },
-                (Some(CDeclarator(name, derived, asmname, attrs, node)), bsz) => {
-                    (Some(CDeclarator::<NodeInfo>(name, derived, asmname,
-                                                  __op_addadd(attrs, happy_var_2), node)), bsz)
-                },
+                (None, expr) => (None, expr),
+                (Some(CDeclarator(name, derived, asmname, attrs, node)), bsz) =>
+                    (Some(CDeclarator(name, derived, asmname, __op_addadd(attrs, happy_var_2), node)), bsz)
             }),
         _ => notHappyAtAll()
     }
@@ -18123,7 +18095,7 @@ fn happyReduce_210() -> ActionReturn {
 }
 
 refute! { fn happyReduction_210<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn62(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CEnumeration::<NodeInfo>, None, Some(reverse(happy_var_4)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn61(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CEnumeration, None, Some(reverse(happy_var_4)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn61(r)) }))
 }
 }
 
@@ -18133,7 +18105,7 @@ fn happyReduce_211() -> ActionReturn {
 }
 
 refute! { fn happyReduction_211<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn62(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CEnumeration::<NodeInfo>, None, Some(reverse(happy_var_4)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn61(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CEnumeration, None, Some(reverse(happy_var_4)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn61(r)) }))
 }
 }
 
@@ -18143,7 +18115,7 @@ fn happyReduce_212() -> ActionReturn {
 }
 
 refute! { fn happyReduction_212<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn62(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CEnumeration::<NodeInfo>, Some(happy_var_3), Some(reverse(happy_var_5)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn61(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CEnumeration, Some(happy_var_3), Some(reverse(happy_var_5)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn61(r)) }))
 }
 }
 
@@ -18153,7 +18125,7 @@ fn happyReduce_213() -> ActionReturn {
 }
 
 refute! { fn happyReduction_213<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn62(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CEnumeration::<NodeInfo>, Some(happy_var_3), Some(reverse(happy_var_5)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn61(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CEnumeration, Some(happy_var_3), Some(reverse(happy_var_5)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn61(r)) }))
 }
 }
 
@@ -18163,7 +18135,7 @@ fn happyReduce_214() -> ActionReturn {
 }
 
 refute! { fn happyReduction_214<T>(HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CEnumeration::<NodeInfo>, Some(happy_var_3), None, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn61(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CEnumeration, Some(happy_var_3), None, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn61(r)) }))
 }
 }
 
@@ -18243,7 +18215,7 @@ fn happyReduce_221() -> ActionReturn {
 }
 
 refute! { fn happyReduction_221<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CConstQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CConstQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
 }
 }
 
@@ -18253,7 +18225,7 @@ fn happyReduce_222() -> ActionReturn {
 }
 
 refute! { fn happyReduction_222<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CVolatQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CVolatQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
 }
 }
 
@@ -18263,7 +18235,7 @@ fn happyReduce_223() -> ActionReturn {
 }
 
 refute! { fn happyReduction_223<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CRestrQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CRestrQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
 }
 }
 
@@ -18273,7 +18245,7 @@ fn happyReduce_224() -> ActionReturn {
 }
 
 refute! { fn happyReduction_224<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CNullableQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CNullableQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
 }
 }
 
@@ -18283,7 +18255,7 @@ fn happyReduce_225() -> ActionReturn {
 }
 
 refute! { fn happyReduction_225<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CNonnullQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CNonnullQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
 }
 }
 
@@ -18293,7 +18265,7 @@ fn happyReduce_226() -> ActionReturn {
 }
 
 refute! { fn happyReduction_226<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAtomicQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAtomicQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
 }
 }
 
@@ -18452,7 +18424,7 @@ fn happyReduce_240() -> ActionReturn {
 }
 
 refute! { fn happyReduction_240<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(ptrDeclr, happy_var_2, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_2, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -18462,7 +18434,7 @@ fn happyReduce_241() -> ActionReturn {
 }
 
 refute! { fn happyReduction_241<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_2, box move |_0| { ptrDeclr(happy_var_3, vec![], _0) }) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withAttribute(happy_var_1, happy_var_2, partial_1!(ptrDeclr, happy_var_3, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -18472,7 +18444,7 @@ fn happyReduce_242() -> ActionReturn {
 }
 
 refute! { fn happyReduction_242<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -18482,7 +18454,7 @@ fn happyReduce_243() -> ActionReturn {
 }
 
 refute! { fn happyReduction_243<T>(HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_3, box move |_0| { ptrDeclr(happy_var_4, reverse(happy_var_2), _0) }) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withAttribute(happy_var_1, happy_var_3, partial_1!(ptrDeclr, happy_var_4, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -18546,7 +18518,7 @@ fn happyReduce_249() -> ActionReturn {
 }
 
 refute! { fn happyReduction_249<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(ptrDeclr, happy_var_3, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -18556,7 +18528,7 @@ fn happyReduce_250() -> ActionReturn {
 }
 
 refute! { fn happyReduction_250<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(ptrDeclr, happy_var_4, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_4, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -18566,7 +18538,7 @@ fn happyReduce_251() -> ActionReturn {
 }
 
 refute! { fn happyReduction_251<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_3, box move |_0| { ptrDeclr(happy_var_5, reverse(happy_var_2), _0) }) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withAttribute(happy_var_1, happy_var_3, partial_1!(ptrDeclr, happy_var_5, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -18576,7 +18548,7 @@ fn happyReduce_252() -> ActionReturn {
 }
 
 refute! { fn happyReduction_252<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(ptrDeclr, happy_var_2, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_2, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -18586,7 +18558,7 @@ fn happyReduce_253() -> ActionReturn {
 }
 
 refute! { fn happyReduction_253<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -18596,7 +18568,7 @@ fn happyReduce_254() -> ActionReturn {
 }
 
 refute! { fn happyReduction_254<T>(HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_3, box move |_0| { ptrDeclr(happy_var_4, reverse(happy_var_2), _0) }) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withAttribute(happy_var_1, happy_var_3, partial_1!(ptrDeclr, happy_var_4, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -18696,7 +18668,7 @@ fn happyReduce_263() -> ActionReturn {
 }
 
 refute! { fn happyReduction_263<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(ptrDeclr, happy_var_2, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_2, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -18706,7 +18678,7 @@ fn happyReduce_264() -> ActionReturn {
 }
 
 refute! { fn happyReduction_264<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_2, box move |_0| { ptrDeclr(happy_var_3, vec![], _0) }) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withAttribute(happy_var_1, happy_var_2, partial_1!(ptrDeclr, happy_var_3, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -18716,7 +18688,7 @@ fn happyReduce_265() -> ActionReturn {
 }
 
 refute! { fn happyReduction_265<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -18726,7 +18698,7 @@ fn happyReduce_266() -> ActionReturn {
 }
 
 refute! { fn happyReduction_266<T>(HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_3, box move |_0| { ptrDeclr(happy_var_4, reverse(happy_var_2), _0) }) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withAttribute(happy_var_1, happy_var_3, partial_1!(ptrDeclr, happy_var_4, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -18846,7 +18818,7 @@ fn happyReduce_277() -> ActionReturn {
 }
 
 refute! { fn happyReduction_277<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(ptrDeclr, happy_var_2, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_2, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -18856,7 +18828,7 @@ fn happyReduce_278() -> ActionReturn {
 }
 
 refute! { fn happyReduction_278<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -19228,14 +19200,10 @@ fn happyReduce_312() -> ActionReturn {
 
 refute! { fn happyReduction_312<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn82(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
-            withNodeInfo(happy_var_1.clone(), box move |at| {
-                clones!(happy_var_2);
+            withNodeInfo(happy_var_1, box move |at: NodeInfo| {
                 let a: Rc<Box<Fn(CDeclrR) -> CDeclrR>> = Rc::new(box move |declr| {
-                    match happy_var_2.clone() {
-                        (params, variadic) => {
-                            funDeclr(declr, (Right((params, variadic))), vec![], at.clone())
-                        },
-                    }
+                    let (params, variadic) = happy_var_2.clone();
+                    funDeclr(declr, (Right((params, variadic))), vec![], at.clone())
                 });
                 a
             }) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
@@ -19261,7 +19229,7 @@ fn happyReduce_314() -> ActionReturn {
 
 fn happyReduction_314(happy_x_2: HappyAbsSyn, happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_2, happy_x_1) {
-        (HappyAbsSyn88(happy_var_2), HappyAbsSyn88(happy_var_1)) => HappyAbsSyn88({ let a: Rc<Box<Fn(CDeclrR) -> CDeclrR>> = Rc::new(box move |decl| { happy_var_2(happy_var_1(decl)) }) ; a }),
+        (HappyAbsSyn88(happy_var_2), HappyAbsSyn88(happy_var_1)) => HappyAbsSyn88(Rc::new(box move |decl| { happy_var_2(happy_var_1(decl)) })),
         _ => notHappyAtAll()
     }
 }
@@ -19273,8 +19241,7 @@ fn happyReduce_315() -> ActionReturn {
 
 refute! { fn happyReduction_315<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
-            withNodeInfo(happy_var_1.clone(), box move |at| {
-                clones!(happy_var_2);
+            withNodeInfo(happy_var_1.clone(), box move |at: NodeInfo| {
                 let a: Rc<Box<Fn(CDeclrR) -> CDeclrR>> = Rc::new(box move |declr| {
                     arrDeclr(declr, vec![], false, false, happy_var_2.clone(), at.clone())
                 });
@@ -19289,7 +19256,8 @@ fn happyReduce_316() -> ActionReturn {
 }
 
 refute! { fn happyReduction_316<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttributePF(happy_var_1, happy_var_2, box |at, declr| { arrDeclr(declr, vec![], false, false, happy_var_3, at) }) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+    happyThen({ withAttributePF(happy_var_1, happy_var_2, box move |at, declr|
+                           arrDeclr(declr, vec![], false, false, happy_var_3.clone(), at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
 }
 }
 
@@ -19300,8 +19268,7 @@ fn happyReduce_317() -> ActionReturn {
 
 refute! { fn happyReduction_317<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
-            withNodeInfo(happy_var_1.clone(), box move |at| {
-                clones!(happy_var_2, happy_var_3);
+            withNodeInfo(happy_var_1.clone(), box move |at: NodeInfo| {
                 let a: Rc<Box<Fn(CDeclrR) -> CDeclrR>> = Rc::new(
                     box move |declr| { arrDeclr(declr, reverse(happy_var_2.clone()),
                                                 false, false, happy_var_3.clone(), at.clone()) });
@@ -19316,7 +19283,8 @@ fn happyReduce_318() -> ActionReturn {
 }
 
 refute! { fn happyReduction_318<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttributePF(happy_var_1, happy_var_3, box |at, declr| { arrDeclr(declr, reverse(happy_var_2), false, false, happy_var_4, at) }) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+    happyThen({ withAttributePF(happy_var_1, happy_var_3, box move |at, declr|
+                           arrDeclr(declr, reverse(happy_var_2.clone()), false, false, happy_var_4.clone(), at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
 }
 }
 
@@ -19326,7 +19294,8 @@ fn happyReduce_319() -> ActionReturn {
 }
 
 refute! { fn happyReduction_319<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttributePF(happy_var_1, happy_var_3, box |at, declr| { arrDeclr(declr, vec![], false, true, Some(happy_var_4), at) }) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+    happyThen({ withAttributePF(happy_var_1, happy_var_3, box move |at, declr|
+                           arrDeclr(declr, vec![], false, true, Some(happy_var_4.clone()), at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
 }
 }
 
@@ -19336,7 +19305,8 @@ fn happyReduce_320() -> ActionReturn {
 }
 
 refute! { fn happyReduction_320<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_5), Some(box HappyStk(HappyAbsSyn132(happy_var_4), Some(box HappyStk(HappyAbsSyn65(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttributePF(happy_var_1, happy_var_4, box |at, declr| { arrDeclr(declr, reverse(happy_var_3), false, true, Some(happy_var_5), at) }) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+    happyThen({ withAttributePF(happy_var_1, happy_var_4, box move |at, declr|
+                           arrDeclr(declr, reverse(happy_var_3.clone()), false, true, Some(happy_var_5.clone()), at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
 }
 }
 
@@ -19346,8 +19316,8 @@ fn happyReduce_321() -> ActionReturn {
 }
 
 refute! { fn happyReduction_321<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_6), Some(box HappyStk(HappyAbsSyn132(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttributePF(happy_var_1, __op_addadd(happy_var_3, happy_var_5),
-                           box |at, declr| { arrDeclr(declr, reverse(happy_var_2), false, true, Some(happy_var_6), at) }) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+    happyThen({ withAttributePF(happy_var_1, __op_addadd(happy_var_3, happy_var_5), box move |at, declr|
+                           arrDeclr(declr, reverse(happy_var_2.clone()), false, true, Some(happy_var_6.clone()), at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
 }
 }
 
@@ -19357,7 +19327,8 @@ fn happyReduce_322() -> ActionReturn {
 }
 
 refute! { fn happyReduction_322<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttributePF(happy_var_1, happy_var_3, box |at, declr| { arrDeclr(declr, vec![], true, false, None, at) }) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+    happyThen({ withAttributePF(happy_var_1, happy_var_3, box move |at, declr|
+                           arrDeclr(declr, vec![], true, false, None, at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
 }
 }
 
@@ -19367,8 +19338,8 @@ fn happyReduce_323() -> ActionReturn {
 }
 
 refute! { fn happyReduction_323<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttributePF(happy_var_1, __op_addadd(happy_var_2, happy_var_4),
-                           box |at, declr| { arrDeclr(declr, vec![], true, false, None, at) }) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+    happyThen({ withAttributePF(happy_var_1, __op_addadd(happy_var_2, happy_var_4), box move |at, declr|
+                           arrDeclr(declr, vec![], true, false, None, at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
 }
 }
 
@@ -19378,7 +19349,8 @@ fn happyReduce_324() -> ActionReturn {
 }
 
 refute! { fn happyReduction_324<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttributePF(happy_var_1, happy_var_4, box |at, declr| { arrDeclr(declr, reverse(happy_var_2), true, false, None, at) }) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+    happyThen({ withAttributePF(happy_var_1, happy_var_4, box move |at, declr|
+                           arrDeclr(declr, reverse(happy_var_2.clone()), true, false, None, at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
 }
 }
 
@@ -19388,8 +19360,8 @@ fn happyReduce_325() -> ActionReturn {
 }
 
 refute! { fn happyReduction_325<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttributePF(happy_var_1, __op_addadd(happy_var_3, happy_var_5),
-                           box |at, declr| { arrDeclr(declr, reverse(happy_var_2), true, false, None, at) }) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+    happyThen({ withAttributePF(happy_var_1, __op_addadd(happy_var_3, happy_var_5), box move |at, declr|
+                           arrDeclr(declr, reverse(happy_var_2.clone()), true, false, None, at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
 }
 }
 
@@ -19399,7 +19371,7 @@ fn happyReduce_326() -> ActionReturn {
 }
 
 refute! { fn happyReduction_326<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(ptrDeclr, emptyDeclr(), vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, emptyDeclr(), vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -19409,7 +19381,7 @@ fn happyReduce_327() -> ActionReturn {
 }
 
 refute! { fn happyReduction_327<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_3, box move |_0| { ptrDeclr(emptyDeclr(), reverse(happy_var_2), _0) }) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withAttribute(happy_var_1, happy_var_3, partial_1!(ptrDeclr, emptyDeclr(), reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -19419,7 +19391,7 @@ fn happyReduce_328() -> ActionReturn {
 }
 
 refute! { fn happyReduction_328<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(ptrDeclr, happy_var_2, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_2, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -19429,7 +19401,7 @@ fn happyReduce_329() -> ActionReturn {
 }
 
 refute! { fn happyReduction_329<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -19439,7 +19411,7 @@ fn happyReduce_330() -> ActionReturn {
 }
 
 refute! { fn happyReduction_330<T>(HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_2, box move |_0| { ptrDeclr(emptyDeclr(), vec![], _0) }) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withAttribute(happy_var_1, happy_var_2, partial_1!(ptrDeclr, emptyDeclr(), vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -19449,7 +19421,7 @@ fn happyReduce_331() -> ActionReturn {
 }
 
 refute! { fn happyReduction_331<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_2, box move |_0| { ptrDeclr(happy_var_3, vec![], _0) }) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withAttribute(happy_var_1, happy_var_2, partial_1!(ptrDeclr, happy_var_3, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -19567,7 +19539,7 @@ fn happyReduce_342() -> ActionReturn {
 }
 
 refute! { fn happyReduction_342<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn95(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CInitList, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn93(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CInitList, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn93(r)) }))
 }
 }
 
@@ -19577,7 +19549,7 @@ fn happyReduce_343() -> ActionReturn {
 }
 
 refute! { fn happyReduction_343<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn95(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CInitList, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn93(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CInitList, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn93(r)) }))
 }
 }
 
@@ -19679,7 +19651,7 @@ fn happyReduce_352() -> ActionReturn {
 }
 
 refute! { fn happyReduction_352<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box |at| { vec![CMemberDesig(happy_var_1, at)] }) }, (box move |r| { happyReturn(HappyAbsSyn96(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), box |_0| vec![CMemberDesig(happy_var_1, _0)]) }, (box move |r| { happyReturn(HappyAbsSyn96(r)) }))
 }
 }
 
@@ -19725,7 +19697,7 @@ fn happyReduce_356() -> ActionReturn {
 }
 
 refute! { fn happyReduction_356<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CArrDesig, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn98(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CArrDesig, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn98(r)) }))
 }
 }
 
@@ -19735,7 +19707,7 @@ fn happyReduce_357() -> ActionReturn {
 }
 
 refute! { fn happyReduction_357<T>(HappyStk(HappyAbsSyn131(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CMemberDesig, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn98(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CMemberDesig, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn98(r)) }))
 }
 }
 
@@ -19757,7 +19729,7 @@ fn happyReduce_359() -> ActionReturn {
 }
 
 refute! { fn happyReduction_359<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CRangeDesig, happy_var_2, happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn98(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CRangeDesig, happy_var_2, happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn98(r)) }))
 }
 }
 
@@ -19813,7 +19785,7 @@ fn happyReduce_364() -> ActionReturn {
 }
 
 refute! { fn happyReduction_364<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn101(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CGenericSelection, box happy_var_3, reverse(happy_var_5))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CGenericSelection, box happy_var_3, reverse(happy_var_5))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -19823,7 +19795,7 @@ fn happyReduce_365() -> ActionReturn {
 }
 
 refute! { fn happyReduction_365<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn12(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CStatExpr, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CStatExpr, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -19833,7 +19805,7 @@ fn happyReduce_366() -> ActionReturn {
 }
 
 refute! { fn happyReduction_366<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| { CBuiltinExpr(box CBuiltinVaArg(happy_var_3, happy_var_5, _0)) }) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, box move |_0| CBuiltinExpr(box CBuiltinVaArg(happy_var_3, happy_var_5, _0))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -19843,7 +19815,7 @@ fn happyReduce_367() -> ActionReturn {
 }
 
 refute! { fn happyReduction_367<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn97(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| { CBuiltinExpr(box CBuiltinOffsetOf(happy_var_3, reverse(happy_var_5), _0)) }) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, box move |_0| CBuiltinExpr(box CBuiltinOffsetOf(happy_var_3, reverse(happy_var_5), _0))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -19853,7 +19825,7 @@ fn happyReduce_368() -> ActionReturn {
 }
 
 refute! { fn happyReduction_368<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| { CBuiltinExpr(box CBuiltinTypesCompatible(happy_var_3, happy_var_5, _0)) }) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, box move |_0| CBuiltinExpr(box CBuiltinTypesCompatible(happy_var_3, happy_var_5, _0))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -19911,7 +19883,7 @@ fn happyReduce_373() -> ActionReturn {
 }
 
 refute! { fn happyReduction_373<T>(HappyStk(HappyAbsSyn131(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| { singleton(CMemberDesig(happy_var_1, _0)) }) }, (box move |r| { happyReturn(HappyAbsSyn97(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| singleton(CMemberDesig(happy_var_1, _0))) }, (box move |r| { happyReturn(HappyAbsSyn97(r)) }))
 }
 }
 
@@ -19921,7 +19893,7 @@ fn happyReduce_374() -> ActionReturn {
 }
 
 refute! { fn happyReduction_374<T>(HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn97(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_3.clone(), box move |_0| { snoc(happy_var_1, CMemberDesig(happy_var_3, _0)) }) }, (box move |r| { happyReturn(HappyAbsSyn97(r)) }))
+    happyThen({ withNodeInfo(happy_var_3.clone(), box move |_0| snoc(happy_var_1, CMemberDesig(happy_var_3, _0))) }, (box move |r| { happyReturn(HappyAbsSyn97(r)) }))
 }
 }
 
@@ -19931,7 +19903,7 @@ fn happyReduce_375() -> ActionReturn {
 }
 
 refute! { fn happyReduction_375<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn97(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_3.clone(), box move |_0| { snoc(happy_var_1, CArrDesig(happy_var_3, _0)) }) }, (box move |r| { happyReturn(HappyAbsSyn97(r)) }))
+    happyThen({ withNodeInfo(happy_var_3.clone(), box move |_0| snoc(happy_var_1, CArrDesig(happy_var_3, _0))) }, (box move |r| { happyReturn(HappyAbsSyn97(r)) }))
 }
 }
 
@@ -20023,7 +19995,7 @@ fn happyReduce_384() -> ActionReturn {
 }
 
 refute! { fn happyReduction_384<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn95(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCompoundLit, box happy_var_2, reverse(happy_var_5))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCompoundLit, box happy_var_2, reverse(happy_var_5))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -20033,7 +20005,7 @@ fn happyReduce_385() -> ActionReturn {
 }
 
 refute! { fn happyReduction_385<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn95(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCompoundLit, box happy_var_2, reverse(happy_var_5))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCompoundLit, box happy_var_2, reverse(happy_var_5))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -20079,7 +20051,7 @@ fn happyReduce_389() -> ActionReturn {
 }
 
 refute! { fn happyReduction_389<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CUnary, CPreIncOp, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CUnary, CPreIncOp, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -20089,7 +20061,7 @@ fn happyReduce_390() -> ActionReturn {
 }
 
 refute! { fn happyReduction_390<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CUnary, CPreDecOp, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CUnary, CPreDecOp, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -20121,7 +20093,7 @@ fn happyReduce_393() -> ActionReturn {
 }
 
 refute! { fn happyReduction_393<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CSizeofExpr, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CSizeofExpr, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -20131,7 +20103,7 @@ fn happyReduce_394() -> ActionReturn {
 }
 
 refute! { fn happyReduction_394<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CSizeofType, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CSizeofType, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -20141,7 +20113,7 @@ fn happyReduce_395() -> ActionReturn {
 }
 
 refute! { fn happyReduction_395<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAlignofExpr, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAlignofExpr, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -20151,7 +20123,7 @@ fn happyReduce_396() -> ActionReturn {
 }
 
 refute! { fn happyReduction_396<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAlignofType, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAlignofType, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -20161,7 +20133,7 @@ fn happyReduce_397() -> ActionReturn {
 }
 
 refute! { fn happyReduction_397<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CComplexReal, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CComplexReal, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -20171,7 +20143,7 @@ fn happyReduce_398() -> ActionReturn {
 }
 
 refute! { fn happyReduction_398<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CComplexImag, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CComplexImag, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -20181,7 +20153,7 @@ fn happyReduce_399() -> ActionReturn {
 }
 
 refute! { fn happyReduction_399<T>(HappyStk(HappyAbsSyn131(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CLabAddrExpr, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CLabAddrExpr, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -20275,7 +20247,7 @@ fn happyReduce_407() -> ActionReturn {
 }
 
 refute! { fn happyReduction_407<T>(HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCast, box happy_var_2, box happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCast, box happy_var_2, box happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -20785,8 +20757,7 @@ fn happyReduce_453() -> ActionReturn {
 refute! { fn happyReduction_453<T>(HappyStk(HappyAbsSyn105(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             let es = reverse(happy_var_3);
-            clones!(happy_var_1);
-            withNodeInfo(es.clone(), partial_1!(CComma, __op_concat(happy_var_1.clone(), es.clone()))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+            withNodeInfo(es.clone(), partial_1!(CComma, __op_concat(happy_var_1, es))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
 }
 }
 
@@ -20932,7 +20903,7 @@ refute! { fn happyReduction_464<T>(HappyStk(HappyTerminal(happy_var_1), Some(box
     happyThen({
             withNodeInfo(happy_var_1.clone(), box move |_0| {
                 if let CTokSLit(_, s) = happy_var_1 {
-                    CStringLiteral::<NodeInfo>(s, _0)
+                    CStringLiteral(s, _0)
                 } else {
                     panic!("irrefutable pattern")
                 }
@@ -20949,7 +20920,7 @@ refute! { fn happyReduction_465<T>(HappyStk(HappyAbsSyn129(happy_var_2), Some(bo
     happyThen({
             withNodeInfo(happy_var_1.clone(), box move |_0| {
                 if let CTokSLit(_, s) = happy_var_1 {
-                    CStringLiteral::<NodeInfo>(concatCStrings(__op_concat(s, reverse(happy_var_2))), _0)
+                    CStringLiteral(concatCStrings(__op_concat(s, reverse(happy_var_2))), _0)
                 } else {
                     panic!("irrefutable pattern")
                 }
@@ -21129,7 +21100,7 @@ fn happyReduce_479() -> ActionReturn {
 }
 
 refute! { fn happyReduction_479<T>(HappyStk(HappyTerminal(CTokIdent(_, happy_var_1)), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| { Some(CAttribute::<NodeInfo>(happy_var_1, vec![], _0)) }) }, (box move |r| { happyReturn(HappyAbsSyn136(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| Some(CAttribute(happy_var_1, vec![], _0))) }, (box move |r| { happyReturn(HappyAbsSyn136(r)) }))
 }
 }
 
@@ -21139,8 +21110,7 @@ fn happyReduce_480() -> ActionReturn {
 }
 
 refute! { fn happyReduction_480<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| { Some(CAttribute::<NodeInfo>(
-            internalIdent("const".to_string()), vec![], _0)) }) }, (box move |r| { happyReturn(HappyAbsSyn136(r)) }))
+    happyThen({ withNodeInfo(happy_var_1, box move |_0| Some(CAttribute(internalIdent("const".to_string()), vec![], _0))) }, (box move |r| { happyReturn(HappyAbsSyn136(r)) }))
 }
 }
 
@@ -21150,7 +21120,7 @@ fn happyReduce_481() -> ActionReturn {
 }
 
 refute! { fn happyReduction_481<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn105(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(CTokIdent(_, happy_var_1)), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| { Some(CAttribute::<NodeInfo>(happy_var_1, reverse(happy_var_3), _0)) }) }, (box move |r| { happyReturn(HappyAbsSyn136(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| Some(CAttribute(happy_var_1, reverse(happy_var_3), _0))) }, (box move |r| { happyReturn(HappyAbsSyn136(r)) }))
 }
 }
 
@@ -21160,7 +21130,7 @@ fn happyReduce_482() -> ActionReturn {
 }
 
 refute! { fn happyReduction_482<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(CTokIdent(_, happy_var_1)), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| { Some(CAttribute::<NodeInfo>(happy_var_1, vec![], _0)) }) }, (box move |r| { happyReturn(HappyAbsSyn136(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| Some(CAttribute(happy_var_1, vec![], _0))) }, (box move |r| { happyReturn(HappyAbsSyn136(r)) }))
 }
 }
 
@@ -21414,7 +21384,6 @@ fn reverseList<a>(l: Vec<a>) -> Reversed<Vec<a>> {
     Reversed(List::reverse(l))
 }
 
-
 /// We occasionally need things to have a location when they don't naturally
 /// have one built in as tokens and most AST elements do.
 #[derive(Clone)]
@@ -21430,22 +21399,17 @@ fn unL<T>(Located(a, pos): Located<T>) -> T {
     a
 }
 
-fn withNodeInfo<a: Clone + 'static, node: Pos + Clone + 'static>(
-    node: node, mkAttrNode: Box<Fn(NodeInfo) -> a>) -> P<a>
-{
-    let mkAttrNode = Rc::new(mkAttrNode);
-    thenP(getNewName(), box move |name: Name| {
-        let node = node.clone();
-        let mkAttrNode = mkAttrNode.clone();
+fn withNodeInfo<T: 'static, N: Pos + 'static>(node: N, mkAttrNode: Box<FnBox(NodeInfo) -> T>) -> P<T> {
+    thenP(getNewName(), box |name: Name| {
         thenP(getSavedToken(), box move |lastTok| {
-            let firstPos = posOf(node.clone());
+            let firstPos = posOf(node);
             let attrs = NodeInfo::new(firstPos, posLenOfTok(lastTok), name);
             __return(mkAttrNode(attrs))
         })
     })
 }
 
-fn withLength<a: Clone + 'static>(nodeinfo: NodeInfo, mkAttrNode: Box<Fn(NodeInfo) -> a>) -> P<a> {
+fn withLength<a: Clone + 'static>(nodeinfo: NodeInfo, mkAttrNode: Box<FnBox(NodeInfo) -> a>) -> P<a> {
     thenP(getSavedToken(), box move |lastTok| {
         let firstPos = nodeinfo.clone().pos();
         let attrs = NodeInfo::new(firstPos, posLenOfTok(lastTok),
@@ -21455,7 +21419,11 @@ fn withLength<a: Clone + 'static>(nodeinfo: NodeInfo, mkAttrNode: Box<Fn(NodeInf
 }
 
 #[derive(Clone)]
-pub struct CDeclrR(Option<Ident>, Reversed<Vec<CDerivedDeclr>>, Option<CStringLiteral<NodeInfo>>, Vec<CAttribute<NodeInfo>>, NodeInfo);
+pub struct CDeclrR(Option<Ident>,
+                   Reversed<Vec<CDerivedDeclr>>,
+                   Option<CStringLiteral<NodeInfo>>,
+                   Vec<CAttribute<NodeInfo>>,
+                   NodeInfo);
 
 impl CNode for CDeclrR {
     fn nodeInfo(self) -> NodeInfo {
@@ -21470,73 +21438,59 @@ impl Pos for CDeclrR {
 }
 
 fn reverseDeclr(CDeclrR(ide, reversedDDs, asmname, cattrs, at): CDeclrR) -> CDeclarator<NodeInfo> {
-    CDeclarator::<NodeInfo>(ide, (reverse(reversedDDs)), asmname, cattrs, at)
+    CDeclarator::<NodeInfo>(ide, reverse(reversedDDs), asmname, cattrs, at)
 }
 
-fn withAttribute<node: Pos + Clone + 'static>(node: node, cattrs: Vec<CAttribute<NodeInfo>>, mkDeclrNode: Box<Fn(NodeInfo) -> CDeclrR>) -> P<CDeclrR> {
-    /*do*/ {
-        thenP(getNewName(), box move |name| {
-            let attrs = NodeInfo::with_pos_name(node.clone().posOf(), name);
-
-            let newDeclr = appendDeclrAttrs(cattrs.clone(), mkDeclrNode(attrs));
-
-            __return(newDeclr)
-        })
-    }
+fn withAttribute<node: Pos + 'static>(node: node, cattrs: Vec<CAttribute<NodeInfo>>,
+                                      mkDeclrNode: Box<FnBox(NodeInfo) -> CDeclrR>) -> P<CDeclrR> {
+    thenP(getNewName(), box move |name| {
+        let attrs = NodeInfo::with_pos_name(node.posOf(), name);
+        let newDeclr = appendDeclrAttrs(cattrs.clone(), mkDeclrNode(attrs));
+        __return(newDeclr)
+    })
 }
 
-fn withAttributePF<node: Pos + Clone + 'static>(node: node, cattrs: Vec<CAttribute<NodeInfo>>, mkDeclrCtor: Box<Fn(NodeInfo, CDeclrR) -> CDeclrR>) -> P<Rc<Box<Fn(CDeclrR) -> CDeclrR>>> {
-            let mkDeclrCtor = Rc::new(mkDeclrCtor);
-    /*do*/ {
-        thenP(getNewName(), box move |name| {
-                let mkDeclrCtor = mkDeclrCtor.clone();
-            let attrs = NodeInfo::with_pos_name(node.clone().posOf(), name);
-
-            let cattrs = cattrs.clone();
-
-            let newDeclr: Box<Fn(CDeclrR) -> CDeclrR> = box move |_0| {
-                let mkDeclrCtor = mkDeclrCtor.clone();
-                appendDeclrAttrs(cattrs.clone(), mkDeclrCtor(attrs.clone(), _0)) };
-
-            __return(Rc::new(newDeclr))
-        })
-    }
+fn withAttributePF<N: Pos + 'static>(
+    node: N, cattrs: Vec<CAttribute<NodeInfo>>,
+    mkDeclrCtor: Box<Fn(NodeInfo, CDeclrR) -> CDeclrR>) -> P<Rc<Box<Fn(CDeclrR) -> CDeclrR>>>
+{
+    let mkDeclrCtor = Rc::new(mkDeclrCtor);
+    thenP(getNewName(), box move |name| {
+        let attrs = NodeInfo::with_pos_name(node.posOf(), name);
+        let newDeclr: Rc<Box<Fn(CDeclrR) -> CDeclrR>> = Rc::new(box move |_0| {
+            appendDeclrAttrs(cattrs.clone(), mkDeclrCtor(attrs.clone(), _0))
+        });
+        __return(newDeclr)
+    })
 }
 
-fn appendObjAttrs(newAttrs: Vec<CAttribute<NodeInfo>>, CDeclarator(ident, indirections, asmname, cAttrs, at): CDeclarator<NodeInfo>) -> CDeclarator<NodeInfo> {
-    CDeclarator::<NodeInfo>(ident, indirections, asmname, (__op_addadd(cAttrs, newAttrs)), at)
+fn appendObjAttrs(newAttrs: Vec<CAttribute<NodeInfo>>,
+                  CDeclarator(ident, indirections, asmname, cAttrs, at): CDeclarator<NodeInfo>)
+                  -> CDeclarator<NodeInfo> {
+    CDeclarator(ident, indirections, asmname, __op_addadd(cAttrs, newAttrs), at)
 }
 
-fn appendObjAttrsR(newAttrs: Vec<CAttribute<NodeInfo>>, CDeclrR(ident, indirections, asmname, cAttrs, at): CDeclrR) -> CDeclrR {
-    CDeclrR(ident, indirections, asmname, (__op_addadd(cAttrs, newAttrs)), at)
+fn appendObjAttrsR(newAttrs: Vec<CAttribute<NodeInfo>>,
+                   CDeclrR(ident, indirections, asmname, cAttrs, at): CDeclrR) -> CDeclrR {
+    CDeclrR(ident, indirections, asmname, __op_addadd(cAttrs, newAttrs), at)
 }
 
-fn setAsmName(mAsmName: Option<CStringLiteral<NodeInfo>>, CDeclrR(ident, indirections, oldName, cattrs, at): CDeclrR) -> P<CDeclrR> {
+fn setAsmName(mAsmName: Option<CStringLiteral<NodeInfo>>,
+              CDeclrR(ident, indirections, oldName, cattrs, at): CDeclrR) -> P<CDeclrR> {
 
-    let combineName = |_0, _1| {
-        match (_0, _1) {
-            (None, None) => {
-                Right(None)
-            },
-            (None, Some(oldname)) => {
-                Right(Some(oldname))
-            },
-            (Some(newname), None) => {
-                Right(Some(newname))
-            },
-            (Some(n1), Some(n2)) => {
-                Left((n1, n2))
-            },
-        }
+    let combinedName = match (mAsmName, oldName) {
+        (None, None) => Right(None),
+        (None, Some(oldname)) => Right(Some(oldname)),
+        (Some(newname), None) => Right(Some(newname)),
+        (Some(n1), Some(n2)) => Left((n1, n2)),
     };
 
-    let showName = |CStringLiteral(cstr, _)| {
-        show(cstr)
-    };
+    let showName = |CStringLiteral(cstr, _)| show(cstr);
 
-    match combineName(mAsmName, oldName) {
+    match combinedName {
         Left((n1, n2)) => {
-            failP((posOf(n2.clone())), vec!["Duplicate assembler name: ".to_string(), showName(n1), showName(n2)])
+            failP(posOf(n2.clone()),
+                  vec!["Duplicate assembler name: ".to_string(), showName(n1), showName(n2)])
         },
         Right(newName) => {
             __return(CDeclrR(ident, indirections, newName, cattrs, at))
@@ -21544,56 +21498,50 @@ fn setAsmName(mAsmName: Option<CStringLiteral<NodeInfo>>, CDeclrR(ident, indirec
     }
 }
 
-fn withAsmNameAttrs((mAsmName, newAttrs): (Option<CStringLiteral<NodeInfo>>, Vec<CAttribute<NodeInfo>>), declr: CDeclrR) -> P<CDeclrR> {
-    setAsmName(mAsmName, (appendObjAttrsR(newAttrs, declr)))
+fn withAsmNameAttrs((mAsmName, newAttrs): (Option<CStringLiteral<NodeInfo>>, Vec<CAttribute<NodeInfo>>),
+                    declr: CDeclrR) -> P<CDeclrR> {
+    setAsmName(mAsmName, appendObjAttrsR(newAttrs, declr))
 }
 
-fn appendDeclrAttrs(_0: Vec<CAttribute<NodeInfo>>, _1: CDeclrR) -> CDeclrR {
-    match (_0, _1) {
-        (newAttrs, CDeclrR(ident, Reversed(inner), asmname, cattrs, at)) => {
-            let mut inner = inner.clone();
-            if inner.len() == 0 {
-                CDeclrR(ident, empty(), asmname, __op_addadd(cattrs, newAttrs), at)
-            } else {
-                let x = inner.remove(0);
-                let xs = inner;
-                let appendAttrs = |_0| {
-                    match _0 {
-                        CPtrDeclr(typeQuals, at) =>
-                            CPtrDeclr(__op_addadd(typeQuals, __map!(CAttrQual, newAttrs)), at),
-                        CArrDeclr(typeQuals, arraySize, at) =>
-                            CArrDeclr(__op_addadd(typeQuals, __map!(CAttrQual, newAttrs)), arraySize, at),
-                        CFunDeclr(parameters, cattrs, at) =>
-                            CFunDeclr(parameters, __op_addadd(cattrs, newAttrs), at),
-                    }
-                };
-
-                CDeclrR(ident, (Reversed((__op_concat(appendAttrs(x), xs)))), asmname, cattrs, at)
-            }
-        },
+fn appendDeclrAttrs(newAttrs: Vec<CAttribute<NodeInfo>>, declr: CDeclrR) -> CDeclrR {
+    let CDeclrR(ident, Reversed(mut inner), asmname, cattrs, at) = declr;
+    if inner.len() == 0 {
+        CDeclrR(ident, empty(), asmname, __op_addadd(cattrs, newAttrs), at)
+    } else {
+        let x = inner.remove(0);
+        let xs = inner;
+        let appendAttrs = |_0| match _0 {
+            CPtrDeclr(typeQuals, at) =>
+                CPtrDeclr(__op_addadd(typeQuals, __map!(CAttrQual, newAttrs)), at),
+            CArrDeclr(typeQuals, arraySize, at) =>
+                CArrDeclr(__op_addadd(typeQuals, __map!(CAttrQual, newAttrs)), arraySize, at),
+            CFunDeclr(parameters, cattrs, at) =>
+                CFunDeclr(parameters, __op_addadd(cattrs, newAttrs), at),
+        };
+        CDeclrR(ident, Reversed(__op_concat(appendAttrs(x), xs)), asmname, cattrs, at)
     }
 }
 
-fn ptrDeclr(CDeclrR(ident, derivedDeclrs, asmname, cattrs, dat): CDeclrR, tyquals: Vec<CTypeQual>, at: NodeInfo) -> CDeclrR {
-    CDeclrR(ident, (snoc(derivedDeclrs, CPtrDeclr(tyquals, at))), asmname, cattrs, dat)
+fn ptrDeclr(CDeclrR(ident, derivedDeclrs, asmname, cattrs, dat): CDeclrR,
+            tyquals: Vec<CTypeQual>, at: NodeInfo) -> CDeclrR {
+    CDeclrR(ident, snoc(derivedDeclrs, CPtrDeclr(tyquals, at)), asmname, cattrs, dat)
 }
 
-fn funDeclr(CDeclrR(ident, derivedDeclrs, asmname, dcattrs, dat): CDeclrR, params: Either<Vec<Ident>, (Vec<CDecl>, bool)>, cattrs: Vec<CAttribute<NodeInfo>>, at: NodeInfo) -> CDeclrR {
-    CDeclrR(ident, (snoc(derivedDeclrs, CFunDeclr(params, cattrs, at))), asmname, dcattrs, dat)
+fn funDeclr(CDeclrR(ident, derivedDeclrs, asmname, dcattrs, dat): CDeclrR,
+            params: Either<Vec<Ident>, (Vec<CDecl>, bool)>, cattrs: Vec<CAttribute<NodeInfo>>,
+            at: NodeInfo) -> CDeclrR {
+    CDeclrR(ident, snoc(derivedDeclrs, CFunDeclr(params, cattrs, at)), asmname, dcattrs, dat)
 }
 
-fn arrDeclr(CDeclrR(ident, derivedDeclrs, asmname, cattrs, dat): CDeclrR, tyquals: Vec<CTypeQual>, var_sized: bool, static_size: bool, size_expr_opt: Option<CExpr>, at: NodeInfo) -> CDeclrR {
-
+fn arrDeclr(CDeclrR(ident, derivedDeclrs, asmname, cattrs, dat): CDeclrR,
+            tyquals: Vec<CTypeQual>, var_sized: bool, static_size: bool,
+            size_expr_opt: Option<CExpr>, at: NodeInfo) -> CDeclrR {
     let arr_sz = match size_expr_opt {
-        Some(e) => {
-            CArrSize(static_size, e)
-        },
-        None => {
-            CNoArrSize(var_sized)
-        },
+        Some(e) => CArrSize(static_size, e),
+        None => CNoArrSize(var_sized)
     };
 
-    CDeclrR(ident, (snoc(derivedDeclrs, CArrDeclr(tyquals, arr_sz, at))), asmname, cattrs, dat)
+    CDeclrR(ident, snoc(derivedDeclrs, CArrDeclr(tyquals, arr_sz, at)), asmname, cattrs, dat)
 }
 
 fn liftTypeQuals(_curry_0: Reversed<Vec<CTypeQual>>) -> Vec<CDeclSpec> {
@@ -21604,16 +21552,19 @@ fn liftCAttrs(_curry_0: Vec<CAttribute<NodeInfo>>) -> Vec<CDeclSpec> {
     __map!(|_0| CTypeQual(CAttrQual(_0)), _curry_0)
 }
 
-fn addTrailingAttrs(declspecs: Reversed<Vec<CDeclSpec>>, new_attrs: Vec<CAttribute<NodeInfo>>) -> Reversed<Vec<CDeclSpec>> {
+fn addTrailingAttrs(declspecs: Reversed<Vec<CDeclSpec>>,
+                    new_attrs: Vec<CAttribute<NodeInfo>>) -> Reversed<Vec<CDeclSpec>> {
     match viewr(declspecs.clone()) {
         (specs_init, CTypeSpec(CSUType(CStructureUnion(tag, name, Some(def), def_attrs, su_node), node))) => {
-            (snoc(specs_init, CTypeSpec((CSUType((CStructureUnion::<NodeInfo>(tag, name, (Some(def)), (__op_addadd(def_attrs, new_attrs)), su_node)), node)))))
+            snoc(specs_init, CTypeSpec(CSUType(
+                CStructureUnion(tag, name, Some(def), __op_addadd(def_attrs, new_attrs), su_node), node)))
         },
         (specs_init, CTypeSpec(CEnumType(CEnumeration(name, Some(def), def_attrs, e_node), node))) => {
-            (snoc(specs_init, CTypeSpec((CEnumType((CEnumeration::<NodeInfo>(name, (Some(def)), (__op_addadd(def_attrs, new_attrs)), e_node)), node)))))
+            snoc(specs_init, CTypeSpec(CEnumType(
+                CEnumeration(name, Some(def), __op_addadd(def_attrs, new_attrs), e_node), node)))
         },
         _ => {
-            rappend(declspecs, (liftCAttrs(new_attrs)))
+            rappend(declspecs, liftCAttrs(new_attrs))
         },
     }
 }
@@ -21635,11 +21586,11 @@ impl<A: Pos> Pos for Reversed<A> {
 }
 
 fn emptyDeclr() -> CDeclrR {
-    CDeclrR(None, (empty)(), None, vec![], NodeInfo::undef())
+    CDeclrR(None, empty(), None, vec![], NodeInfo::undef())
 }
 
-fn mkVarDeclr(ident: Ident, _curry_1: NodeInfo) -> CDeclrR {
-    CDeclrR((Some(ident)), (empty)(), None, vec![], _curry_1)
+fn mkVarDeclr(ident: Ident, ni: NodeInfo) -> CDeclrR {
+    CDeclrR(Some(ident), empty(), None, vec![], ni)
 }
 
 fn doDeclIdent(declspecs: Vec<CDeclSpec>, CDeclrR(mIdent, _, _, _, _): CDeclrR) -> P<()> {
@@ -21651,9 +21602,7 @@ fn doDeclIdent(declspecs: Vec<CDeclSpec>, CDeclrR(mIdent, _, _, _, _): CDeclrR) 
     };
 
     match mIdent {
-        None => {
-            __return(())
-        },
+        None => __return(()),
         Some(ident) => {
             if any(iypedef, declspecs) { addTypedef(ident) }
             else { shadowTypedef(ident) }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1,6 +1,5 @@
 #![allow(unreachable_patterns)]
 #[macro_use] use corollary_support::*;
-#[macro_use] use matches;
 use std::boxed::FnBox;
 use std::rc::Rc;
 
@@ -51,78 +50,6 @@ macro_rules! apply_5_1_clone {
         }
     )
 }
-macro_rules! clones {
-    ($($value: ident),*) => {
-        $( let $value = $value.clone(); )*
-    }
-}
-
-// Relevant C99 sections:
-//
-// 6.5 Expressions .1 - .17 and 6.6 (almost literally)
-//  Supported GNU extensions:
-//     - Allow a compound statement as an expression
-//     - Various __builtin_* forms that take type parameters
-//     - `alignof' expression or type
-//     - `__extension__' to suppress warnings about extensions
-//     - Allow taking address of a label with: && label
-//     - Omitting the `then' part of conditional expressions
-//     - complex numbers
-//
-// 6.7 C Declarations .1 -.8
-//  Supported GNU extensions:
-//     - '__thread' thread local storage (6.7.1)
-//
-// 6.8 Statements .1 - .8
-//  Supported GNU extensions:
-//    - case ranges (C99 6.8.1)
-//    - '__label__ ident;' declarations (C99 6.8.2)
-//    - computed gotos (C99 6.8.6)
-//
-// 6.9 Translation unit
-//  Supported GNU extensions:
-//     - allow empty translation_unit
-//     - allow redundant ';'
-//     - allow extension keyword before external declaration
-//     - asm definitions
-//
-//  Since some of the grammar productions are quite difficult to read,
-//  (especially those involved with the decleration syntax) we document them
-//  with an extended syntax that allows a more consise representation:
-//
-//  Ordinary rules
-//
-//   foo      named terminal or non-terminal
-//
-//   'c'      terminal, literal character token
-//
-//   A B      concatenation
-//
-//   A | B    alternation
-//
-//   (A)      grouping
-//
-//  Extended rules
-//
-//   A?       optional, short hand for (A|) or [A]{ 0==A || 1==A }
-//
-//   ...      stands for some part of the grammar omitted for clarity
-//
-//   {A}      represents sequences, 0 or more.
-//
-//   <permute> modifier which states that any permutation of the immediate subterms is valid
-//
-//
-//- TODO ----------------------------------------------------------------------
-//
-//  !* We ignore C11 _Atomic type annotations
-//  !* We ignore the C99 static keyword (see C99 6.7.5.3)
-//  !* We do not distinguish in the AST between incomplete array types and
-//      complete variable length arrays ([ '*' ] means the latter). (see C99 6.7.5.2)
-//  !* The AST doesn't allow recording __attribute__ of unnamed struct field
-//     (see , struct_default_declaring_list, struct_identifier_declarator)
-//  !* see `We're being far to liberal here' (... struct definition within structs)
-//  * Documentation isn't complete and consistent yet.
 
 // Parser produced by modified Happy Version 1.19.6
 
@@ -193,12 +120,8 @@ enum HappyAbsSyn {
 use self::HappyAbsSyn::*;
 
 
-type ActionReturn = Box<FnBox(isize, (CToken), HappyState<(CToken), Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>,
-                           Vec<HappyState<(CToken), Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>,
-                           HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>;
-type Action<A, B> = Box<Fn(isize, isize, (CToken), HappyState<(CToken), Box<FnBox(B) -> P<A>>>,
-                           Vec<HappyState<(CToken), Box<FnBox(B) -> P<A>>>>, B) -> P<A>>;
-
+type Monad<T> = P<T>;
+type Token = (CToken);
 fn action_0(i: isize) -> ActionReturn {
     match i {
         7 => partial_5!(happyGoto, curry_1_5!(action_144)),
@@ -15705,7 +15628,8 @@ fn happyReduce_4() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 7, box happyReduction_4)
 }
 
-refute! { fn happyReduction_4<T>(HappyStk(HappyAbsSyn8(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_4<T>(HappyStk(HappyAbsSyn8(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
                       let decls = reverse(happy_var_1);
                       if decls.len() == 0 {
@@ -15718,7 +15642,8 @@ refute! { fn happyReduction_4<T>(HappyStk(HappyAbsSyn8(happy_var_1), Some(box ha
                       } else {
                           let d = decls[0].clone();
                           withNodeInfo(d, box |_0| CTranslationUnit(decls, _0))
-                      } }, (box move |r| { happyReturn(HappyAbsSyn7(r)) }))
+                      } },
+              box move |r| happyReturn(HappyAbsSyn7(r)))
 }
 }
 
@@ -15728,9 +15653,7 @@ fn happyReduce_5() -> ActionReturn {
 }
 
 fn happyReduction_5() -> HappyAbsSyn {
-    match () {
-        () => HappyAbsSyn8(empty()),
-    }
+    HappyAbsSyn8(empty())
 }
 
 
@@ -15798,8 +15721,10 @@ fn happyReduce_11() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 9, box happyReduction_11)
 }
 
-refute! { fn happyReduction_11<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAsmExt, happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn9(r)) }))
+refute! {
+fn happyReduction_11<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAsmExt, happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn9(r)))
 }
 }
 
@@ -15808,9 +15733,11 @@ fn happyReduce_12() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 10, box happyReduction_12)
 }
 
-refute! { fn happyReduction_12<T>(HappyStk(HappyAbsSyn12(happy_var_2), Some(box HappyStk(HappyAbsSyn11(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_12<T>(HappyStk(HappyAbsSyn12(happy_var_2), Some(box HappyStk(HappyAbsSyn11(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef, vec![], happy_var_1, vec![], happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, vec![], happy_var_1, vec![], happy_var_2))) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -15819,9 +15746,11 @@ fn happyReduce_13() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 10, box happyReduction_13)
 }
 
-refute! { fn happyReduction_13<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_13<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef, liftCAttrs(happy_var_1), happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, liftCAttrs(happy_var_1), happy_var_2, vec![], happy_var_3))) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -15830,9 +15759,11 @@ fn happyReduce_14() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 10, box happyReduction_14)
 }
 
-refute! { fn happyReduction_14<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_14<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef, happy_var_1, happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, happy_var_1, happy_var_2, vec![], happy_var_3))) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -15841,9 +15772,11 @@ fn happyReduce_15() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 10, box happyReduction_15)
 }
 
-refute! { fn happyReduction_15<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_15<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef, happy_var_1, happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, happy_var_1, happy_var_2, vec![], happy_var_3))) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -15852,9 +15785,11 @@ fn happyReduce_16() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 10, box happyReduction_16)
 }
 
-refute! { fn happyReduction_16<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_16<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef, reverse(happy_var_1), happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, reverse(happy_var_1), happy_var_2, vec![], happy_var_3))) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -15863,9 +15798,11 @@ fn happyReduce_17() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 10, box happyReduction_17)
 }
 
-refute! { fn happyReduction_17<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_17<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef, liftTypeQuals(happy_var_1), happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, liftTypeQuals(happy_var_1), happy_var_2, vec![], happy_var_3))) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -15874,9 +15811,11 @@ fn happyReduce_18() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 10, box happyReduction_18)
 }
 
-refute! { fn happyReduction_18<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn11(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_18<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn11(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)), happy_var_3, vec![], happy_var_4))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)), happy_var_3, vec![], happy_var_4))) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -15885,8 +15824,10 @@ fn happyReduce_19() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 10, box happyReduction_19)
 }
 
-refute! { fn happyReduction_19<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn33(happy_var_2), Some(box HappyStk(HappyAbsSyn11(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFunctionDef, vec![], happy_var_1, reverse(happy_var_2), happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+refute! {
+fn happyReduction_19<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn33(happy_var_2), Some(box HappyStk(HappyAbsSyn11(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFunctionDef, vec![], happy_var_1, reverse(happy_var_2), happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -15895,8 +15836,10 @@ fn happyReduce_20() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 10, box happyReduction_20)
 }
 
-refute! { fn happyReduction_20<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn33(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2.clone(), partial_1!(CFunctionDef, liftCAttrs(happy_var_1), happy_var_2, reverse(happy_var_3), happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+refute! {
+fn happyReduction_20<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn33(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_2.clone(), partial_1!(CFunctionDef, liftCAttrs(happy_var_1), happy_var_2, reverse(happy_var_3), happy_var_4)) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -15905,8 +15848,10 @@ fn happyReduce_21() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 10, box happyReduction_21)
 }
 
-refute! { fn happyReduction_21<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn33(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFunctionDef, happy_var_1, happy_var_2, reverse(happy_var_3), happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+refute! {
+fn happyReduction_21<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn33(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFunctionDef, happy_var_1, happy_var_2, reverse(happy_var_3), happy_var_4)) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -15915,8 +15860,10 @@ fn happyReduce_22() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 10, box happyReduction_22)
 }
 
-refute! { fn happyReduction_22<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn33(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFunctionDef, happy_var_1, happy_var_2, reverse(happy_var_3), happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+refute! {
+fn happyReduction_22<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn33(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFunctionDef, happy_var_1, happy_var_2, reverse(happy_var_3), happy_var_4)) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -15925,8 +15872,10 @@ fn happyReduce_23() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 10, box happyReduction_23)
 }
 
-refute! { fn happyReduction_23<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn33(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFunctionDef, reverse(happy_var_1), happy_var_2, reverse(happy_var_3), happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+refute! {
+fn happyReduction_23<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn33(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFunctionDef, reverse(happy_var_1), happy_var_2, reverse(happy_var_3), happy_var_4)) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -15935,8 +15884,10 @@ fn happyReduce_24() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 10, box happyReduction_24)
 }
 
-refute! { fn happyReduction_24<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn33(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFunctionDef, liftTypeQuals(happy_var_1), happy_var_2, reverse(happy_var_3), happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+refute! {
+fn happyReduction_24<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn33(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CFunctionDef, liftTypeQuals(happy_var_1), happy_var_2, reverse(happy_var_3), happy_var_4)) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -15945,9 +15896,11 @@ fn happyReduce_25() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 10, box happyReduction_25)
 }
 
-refute! { fn happyReduction_25<T>(HappyStk(HappyAbsSyn12(happy_var_5), Some(box HappyStk(HappyAbsSyn33(happy_var_4), Some(box HappyStk(HappyAbsSyn11(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_25<T>(HappyStk(HappyAbsSyn12(happy_var_5), Some(box HappyStk(HappyAbsSyn33(happy_var_4), Some(box HappyStk(HappyAbsSyn11(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)), happy_var_3, reverse(happy_var_4), happy_var_5)) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)), happy_var_3, reverse(happy_var_4), happy_var_5)) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -15956,10 +15909,12 @@ fn happyReduce_26() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 11, box happyReduction_26)
 }
 
-refute! { fn happyReduction_26<T>(HappyStk(HappyAbsSyn66(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_26<T>(HappyStk(HappyAbsSyn66(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             let declr = reverseDeclr(happy_var_1);
-            rshift_monad(enterScope(), rshift_monad(doFuncParamDeclIdent(declr.clone()), __return(declr))) }, (box move |r| { happyReturn(HappyAbsSyn11(r)) }))
+            rshift_monad(enterScope(), rshift_monad(doFuncParamDeclIdent(declr.clone()), __return(declr))) },
+              box move |r| happyReturn(HappyAbsSyn11(r)))
 }
 }
 
@@ -16040,8 +15995,10 @@ fn happyReduce_33() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 12, box happyReduction_33)
 }
 
-refute! { fn happyReduction_33<T>(HappyStk(HappyAbsSyn26(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAsm, happy_var_1)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_33<T>(HappyStk(HappyAbsSyn26(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAsm, happy_var_1)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16050,8 +16007,10 @@ fn happyReduce_34() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 13, box happyReduction_34)
 }
 
-refute! { fn happyReduction_34<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CLabel, happy_var_1, box happy_var_4, happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_34<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CLabel, happy_var_1, box happy_var_4, happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16060,8 +16019,10 @@ fn happyReduce_35() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 13, box happyReduction_35)
 }
 
-refute! { fn happyReduction_35<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCase, happy_var_2, box happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_35<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCase, happy_var_2, box happy_var_4)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16070,8 +16031,10 @@ fn happyReduce_36() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 13, box happyReduction_36)
 }
 
-refute! { fn happyReduction_36<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CDefault, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_36<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CDefault, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16080,8 +16043,10 @@ fn happyReduce_37() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 13, box happyReduction_37)
 }
 
-refute! { fn happyReduction_37<T>(HappyStk(HappyAbsSyn12(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCases, happy_var_2, happy_var_4, box happy_var_6)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_37<T>(HappyStk(HappyAbsSyn12(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCases, happy_var_2, happy_var_4, box happy_var_6)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16090,8 +16055,10 @@ fn happyReduce_38() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 14, box happyReduction_38)
 }
 
-refute! { fn happyReduction_38<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn17(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCompound, vec![], reverse(happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_38<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn17(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCompound, vec![], reverse(happy_var_3))) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16100,8 +16067,10 @@ fn happyReduce_39() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 14, box happyReduction_39)
 }
 
-refute! { fn happyReduction_39<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn17(happy_var_4), Some(box HappyStk(HappyAbsSyn21(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCompound, reverse(happy_var_3), reverse(happy_var_4))) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_39<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn17(happy_var_4), Some(box HappyStk(HappyAbsSyn21(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCompound, reverse(happy_var_3), reverse(happy_var_4))) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16110,8 +16079,10 @@ fn happyReduce_40() -> ActionReturn {
     partial_5!(happyMonadReduce, 0, 15, box happyReduction_40)
 }
 
-refute! { fn happyReduction_40<T>(happyRest: HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ enterScope() }, (box move |r| { happyReturn(HappyAbsSyn15(r)) }))
+refute! {
+fn happyReduction_40<T>(happyRest: HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ enterScope() },
+              box move |r| happyReturn(HappyAbsSyn15(r)))
 }
 }
 
@@ -16120,8 +16091,10 @@ fn happyReduce_41() -> ActionReturn {
     partial_5!(happyMonadReduce, 0, 16, box happyReduction_41)
 }
 
-refute! { fn happyReduction_41<T>(happyRest: HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ leaveScope() }, (box move |r| { happyReturn(HappyAbsSyn15(r)) }))
+refute! {
+fn happyReduction_41<T>(happyRest: HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ leaveScope() },
+              box move |r| happyReturn(HappyAbsSyn15(r)))
 }
 }
 
@@ -16131,9 +16104,7 @@ fn happyReduce_42() -> ActionReturn {
 }
 
 fn happyReduction_42() -> HappyAbsSyn {
-    match () {
-        () => HappyAbsSyn17(empty()),
-    }
+    HappyAbsSyn17(empty())
 }
 
 
@@ -16213,9 +16184,11 @@ fn happyReduce_49() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 20, box happyReduction_49)
 }
 
-refute! { fn happyReduction_49<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_49<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef, happy_var_1, happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, happy_var_1, happy_var_2, vec![], happy_var_3))) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -16224,9 +16197,11 @@ fn happyReduce_50() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 20, box happyReduction_50)
 }
 
-refute! { fn happyReduction_50<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_50<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef, happy_var_1, happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, happy_var_1, happy_var_2, vec![], happy_var_3))) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -16235,9 +16210,11 @@ fn happyReduce_51() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 20, box happyReduction_51)
 }
 
-refute! { fn happyReduction_51<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_51<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef, reverse(happy_var_1), happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, reverse(happy_var_1), happy_var_2, vec![], happy_var_3))) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -16246,9 +16223,11 @@ fn happyReduce_52() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 20, box happyReduction_52)
 }
 
-refute! { fn happyReduction_52<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_52<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef, liftTypeQuals(happy_var_1), happy_var_2, vec![], happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, liftTypeQuals(happy_var_1), happy_var_2, vec![], happy_var_3))) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -16257,9 +16236,11 @@ fn happyReduce_53() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 20, box happyReduction_53)
 }
 
-refute! { fn happyReduction_53<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn11(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_53<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn11(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
-            CFunctionDef, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)), happy_var_3, vec![], happy_var_4))) }, (box move |r| { happyReturn(HappyAbsSyn10(r)) }))
+            CFunctionDef, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)), happy_var_3, vec![], happy_var_4))) },
+              box move |r| happyReturn(HappyAbsSyn10(r)))
 }
 }
 
@@ -16280,7 +16261,8 @@ fn happyReduce_55() -> ActionReturn {
     partial_5!(happyReduce, 4, 21, box happyReduction_55)
 }
 
-refute! { fn happyReduction_55(HappyStk(_, Some(box HappyStk(HappyAbsSyn21(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn21(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_55(HappyStk(_, Some(box HappyStk(HappyAbsSyn21(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn21(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn21(rappendr(happy_var_1, happy_var_3)), Some(box happyRest))
 }
 }
@@ -16290,8 +16272,10 @@ fn happyReduce_56() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 22, box happyReduction_56)
 }
 
-refute! { fn happyReduction_56<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CExpr, None)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_56<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CExpr, None)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16300,8 +16284,10 @@ fn happyReduce_57() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 22, box happyReduction_57)
 }
 
-refute! { fn happyReduction_57<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CExpr, Some(happy_var_1))) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_57<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CExpr, Some(happy_var_1))) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16310,8 +16296,10 @@ fn happyReduce_58() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 23, box happyReduction_58)
 }
 
-refute! { fn happyReduction_58<T>(HappyStk(HappyAbsSyn12(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CIf, happy_var_3, box happy_var_5, None)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_58<T>(HappyStk(HappyAbsSyn12(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CIf, happy_var_3, box happy_var_5, None)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16320,8 +16308,10 @@ fn happyReduce_59() -> ActionReturn {
     partial_5!(happyMonadReduce, 7, 23, box happyReduction_59)
 }
 
-refute! { fn happyReduction_59<T>(HappyStk(HappyAbsSyn12(happy_var_7), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn12(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CIf, happy_var_3, box happy_var_5, Some(box happy_var_7))) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_59<T>(HappyStk(HappyAbsSyn12(happy_var_7), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn12(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CIf, happy_var_3, box happy_var_5, Some(box happy_var_7))) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16330,8 +16320,10 @@ fn happyReduce_60() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 23, box happyReduction_60)
 }
 
-refute! { fn happyReduction_60<T>(HappyStk(HappyAbsSyn12(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CSwitch, happy_var_3, box happy_var_5)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_60<T>(HappyStk(HappyAbsSyn12(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CSwitch, happy_var_3, box happy_var_5)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16340,8 +16332,10 @@ fn happyReduce_61() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 24, box happyReduction_61)
 }
 
-refute! { fn happyReduction_61<T>(HappyStk(HappyAbsSyn12(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CWhile, happy_var_3, box happy_var_5, false)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_61<T>(HappyStk(HappyAbsSyn12(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CWhile, happy_var_3, box happy_var_5, false)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16350,8 +16344,10 @@ fn happyReduce_62() -> ActionReturn {
     partial_5!(happyMonadReduce, 7, 24, box happyReduction_62)
 }
 
-refute! { fn happyReduction_62<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn12(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CWhile, happy_var_5, box happy_var_2, true)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_62<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn12(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CWhile, happy_var_5, box happy_var_2, true)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16360,8 +16356,10 @@ fn happyReduce_63() -> ActionReturn {
     partial_5!(happyMonadReduce, 9, 24, box happyReduction_63)
 }
 
-refute! { fn happyReduction_63<T>(HappyStk(HappyAbsSyn12(happy_var_9), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_7), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CFor, Left(happy_var_3), happy_var_5, happy_var_7, box happy_var_9)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_63<T>(HappyStk(HappyAbsSyn12(happy_var_9), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_7), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CFor, Left(happy_var_3), happy_var_5, happy_var_7, box happy_var_9)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16370,8 +16368,10 @@ fn happyReduce_64() -> ActionReturn {
     partial_5!(happyMonadReduce, 10, 24, box happyReduction_64)
 }
 
-refute! { fn happyReduction_64<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn12(happy_var_9), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_7), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_5), Some(box HappyStk(HappyAbsSyn32(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CFor, Right(happy_var_4), happy_var_5, happy_var_7, box happy_var_9)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_64<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn12(happy_var_9), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_7), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_5), Some(box HappyStk(HappyAbsSyn32(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CFor, Right(happy_var_4), happy_var_5, happy_var_7, box happy_var_9)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16380,8 +16380,10 @@ fn happyReduce_65() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 25, box happyReduction_65)
 }
 
-refute! { fn happyReduction_65<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CGoto, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_65<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CGoto, happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16390,8 +16392,10 @@ fn happyReduce_66() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 25, box happyReduction_66)
 }
 
-refute! { fn happyReduction_66<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CGotoPtr, happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_66<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CGotoPtr, happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16400,8 +16404,10 @@ fn happyReduce_67() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 25, box happyReduction_67)
 }
 
-refute! { fn happyReduction_67<T>(HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCont)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_67<T>(HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCont)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16410,8 +16416,10 @@ fn happyReduce_68() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 25, box happyReduction_68)
 }
 
-refute! { fn happyReduction_68<T>(HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CBreak)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_68<T>(HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CBreak)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16420,8 +16428,10 @@ fn happyReduce_69() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 25, box happyReduction_69)
 }
 
-refute! { fn happyReduction_69<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CReturn, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn12(r)) }))
+refute! {
+fn happyReduction_69<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CReturn, happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn12(r)))
 }
 }
 
@@ -16430,8 +16440,10 @@ fn happyReduce_70() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 26, box happyReduction_70)
 }
 
-refute! { fn happyReduction_70<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn27(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyStatement, happy_var_2, happy_var_4, vec![], vec![], vec![])) }, (box move |r| { happyReturn(HappyAbsSyn26(r)) }))
+refute! {
+fn happyReduction_70<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn27(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyStatement, happy_var_2, happy_var_4, vec![], vec![], vec![])) },
+              box move |r| happyReturn(HappyAbsSyn26(r)))
 }
 }
 
@@ -16440,8 +16452,10 @@ fn happyReduce_71() -> ActionReturn {
     partial_5!(happyMonadReduce, 8, 26, box happyReduction_71)
 }
 
-refute! { fn happyReduction_71<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn28(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn27(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyStatement, happy_var_2, happy_var_4, happy_var_6, vec![], vec![])) }, (box move |r| { happyReturn(HappyAbsSyn26(r)) }))
+refute! {
+fn happyReduction_71<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn28(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn27(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyStatement, happy_var_2, happy_var_4, happy_var_6, vec![], vec![])) },
+              box move |r| happyReturn(HappyAbsSyn26(r)))
 }
 }
 
@@ -16450,8 +16464,10 @@ fn happyReduce_72() -> ActionReturn {
     partial_5!(happyMonadReduce, 10, 26, box happyReduction_72)
 }
 
-refute! { fn happyReduction_72<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn28(happy_var_8), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn28(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn27(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyStatement, happy_var_2, happy_var_4, happy_var_6, happy_var_8, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn26(r)) }))
+refute! {
+fn happyReduction_72<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn28(happy_var_8), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn28(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn27(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyStatement, happy_var_2, happy_var_4, happy_var_6, happy_var_8, vec![])) },
+              box move |r| happyReturn(HappyAbsSyn26(r)))
 }
 }
 
@@ -16460,8 +16476,10 @@ fn happyReduce_73() -> ActionReturn {
     partial_5!(happyMonadReduce, 12, 26, box happyReduction_73)
 }
 
-refute! { fn happyReduction_73<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn31(happy_var_10), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn28(happy_var_8), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn28(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn27(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyStatement, happy_var_2, happy_var_4, happy_var_6, happy_var_8, reverse(happy_var_10))) }, (box move |r| { happyReturn(HappyAbsSyn26(r)) }))
+refute! {
+fn happyReduction_73<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn31(happy_var_10), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn28(happy_var_8), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn28(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn27(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyStatement, happy_var_2, happy_var_4, happy_var_6, happy_var_8, reverse(happy_var_10))) },
+              box move |r| happyReturn(HappyAbsSyn26(r)))
 }
 }
 
@@ -16471,9 +16489,7 @@ fn happyReduce_74() -> ActionReturn {
 }
 
 fn happyReduction_74() -> HappyAbsSyn {
-    match () {
-        () => HappyAbsSyn27(None),
-    }
+    HappyAbsSyn27(None)
 }
 
 
@@ -16494,9 +16510,7 @@ fn happyReduce_76() -> ActionReturn {
 }
 
 fn happyReduction_76() -> HappyAbsSyn {
-    match () {
-        () => HappyAbsSyn28(vec![]),
-    }
+    HappyAbsSyn28(vec![])
 }
 
 
@@ -16540,8 +16554,10 @@ fn happyReduce_80() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 30, box happyReduction_80)
 }
 
-refute! { fn happyReduction_80<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAssemblyOperand, None, happy_var_1, happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn30(r)) }))
+refute! {
+fn happyReduction_80<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAssemblyOperand, None, happy_var_1, happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn30(r)))
 }
 }
 
@@ -16550,8 +16566,10 @@ fn happyReduce_81() -> ActionReturn {
     partial_5!(happyMonadReduce, 7, 30, box happyReduction_81)
 }
 
-refute! { fn happyReduction_81<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(CTokIdent(_, happy_var_2)), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyOperand, Some(happy_var_2), happy_var_4, happy_var_6)) }, (box move |r| { happyReturn(HappyAbsSyn30(r)) }))
+refute! {
+fn happyReduction_81<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(CTokIdent(_, happy_var_2)), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyOperand, Some(happy_var_2), happy_var_4, happy_var_6)) },
+              box move |r| happyReturn(HappyAbsSyn30(r)))
 }
 }
 
@@ -16560,8 +16578,10 @@ fn happyReduce_82() -> ActionReturn {
     partial_5!(happyMonadReduce, 7, 30, box happyReduction_82)
 }
 
-refute! { fn happyReduction_82<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_2)), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyOperand, Some(happy_var_2), happy_var_4, happy_var_6)) }, (box move |r| { happyReturn(HappyAbsSyn30(r)) }))
+refute! {
+fn happyReduction_82<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_6), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_2)), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAssemblyOperand, Some(happy_var_2), happy_var_4, happy_var_6)) },
+              box move |r| happyReturn(HappyAbsSyn30(r)))
 }
 }
 
@@ -16594,8 +16614,10 @@ fn happyReduce_85() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 32, box happyReduction_85)
 }
 
-refute! { fn happyReduction_85<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, reverse(happy_var_1), vec![])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+refute! {
+fn happyReduction_85<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, reverse(happy_var_1), vec![])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -16604,8 +16626,10 @@ fn happyReduce_86() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 32, box happyReduction_86)
 }
 
-refute! { fn happyReduction_86<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, reverse(happy_var_1), vec![])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+refute! {
+fn happyReduction_86<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, reverse(happy_var_1), vec![])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -16614,13 +16638,15 @@ fn happyReduce_87() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 32, box happyReduction_87)
 }
 
-refute! { fn happyReduction_87<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_87<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             if let CDecl(declspecs, dies, at) = happy_var_1 {
                 withLength(at, partial_1!(CDecl, declspecs, List::reverse(dies)))
             } else {
                 panic!("irrefutable pattern")
-            } }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+            } },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -16629,13 +16655,15 @@ fn happyReduce_88() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 32, box happyReduction_88)
 }
 
-refute! { fn happyReduction_88<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_88<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             if let CDecl(declspecs, dies, at) = happy_var_1 {
                 withLength(at, partial_1!(CDecl, declspecs, List::reverse(dies)))
             } else {
                 panic!("irrefutable pattern")
-            } }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+            } },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -16644,8 +16672,10 @@ fn happyReduce_89() -> ActionReturn {
     partial_5!(happyMonadReduce, 7, 32, box happyReduction_89)
 }
 
-refute! { fn happyReduction_89<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CStaticAssert, happy_var_3, happy_var_5)) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+refute! {
+fn happyReduction_89<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CStaticAssert, happy_var_3, happy_var_5)) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -16655,9 +16685,7 @@ fn happyReduce_90() -> ActionReturn {
 }
 
 fn happyReduction_90() -> HappyAbsSyn {
-    match () {
-        () => HappyAbsSyn33(empty()),
-    }
+    HappyAbsSyn33(empty())
 }
 
 
@@ -16677,7 +16705,8 @@ fn happyReduce_92() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 34, box happyReduction_92)
 }
 
-refute! { fn happyReduction_92<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_92<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             let declspecs = reverse(happy_var_1.clone());
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
@@ -16686,7 +16715,8 @@ refute! { fn happyReduction_92<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box 
                     doDeclIdent(declspecs.clone(), declr.clone()),
                     withNodeInfo(happy_var_1, partial_1!(CDecl, declspecs,
                                                 vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
-            }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+            }) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -16695,7 +16725,8 @@ fn happyReduce_93() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 34, box happyReduction_93)
 }
 
-refute! { fn happyReduction_93<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_93<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             let declspecs = liftTypeQuals(happy_var_1.clone());
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
@@ -16703,7 +16734,8 @@ refute! { fn happyReduction_93<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box 
                     doDeclIdent(declspecs.clone(), declr.clone()),
                     withNodeInfo(happy_var_1, partial_1!(CDecl, declspecs,
                                                 vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
-            }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+            }) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -16712,7 +16744,8 @@ fn happyReduce_94() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 34, box happyReduction_94)
 }
 
-refute! { fn happyReduction_94<T>(HappyStk(HappyAbsSyn94(happy_var_5), Some(box HappyStk(HappyAbsSyn35(happy_var_4), Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_94<T>(HappyStk(HappyAbsSyn94(happy_var_5), Some(box HappyStk(HappyAbsSyn35(happy_var_4), Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             let declspecs = liftTypeQuals(happy_var_1.clone());
             thenP(withAsmNameAttrs(happy_var_4, happy_var_3), box move |declr: CDeclrR| {
@@ -16720,7 +16753,8 @@ refute! { fn happyReduction_94<T>(HappyStk(HappyAbsSyn94(happy_var_5), Some(box 
                     doDeclIdent(declspecs.clone(), declr.clone()),
                     withNodeInfo(happy_var_1, partial_1!(CDecl, __op_addadd(declspecs, liftCAttrs(happy_var_2)),
                                                 vec![(Some(reverseDeclr(declr)), happy_var_5, None)])))
-            }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+            }) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -16729,7 +16763,8 @@ fn happyReduce_95() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 34, box happyReduction_95)
 }
 
-refute! { fn happyReduction_95<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_95<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             let declspecs = liftCAttrs(happy_var_1.clone());
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
@@ -16737,7 +16772,8 @@ refute! { fn happyReduction_95<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box 
                     doDeclIdent(declspecs.clone(), declr.clone()),
                     withNodeInfo(happy_var_1, partial_1!(CDecl, declspecs,
                                                 vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
-            }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+            }) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -16746,7 +16782,8 @@ fn happyReduce_96() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 34, box happyReduction_96)
 }
 
-refute! { fn happyReduction_96<T>(HappyStk(HappyAbsSyn94(happy_var_6), Some(box HappyStk(HappyAbsSyn35(happy_var_5), Some(box HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_96<T>(HappyStk(HappyAbsSyn94(happy_var_6), Some(box HappyStk(HappyAbsSyn35(happy_var_5), Some(box HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             if let CDecl(declspecs, dies, at) = happy_var_1 {
                 let (f, s) = happy_var_5;
@@ -16758,7 +16795,8 @@ refute! { fn happyReduction_96<T>(HappyStk(HappyAbsSyn94(happy_var_6), Some(box 
                 })
             } else {
                 panic!("irrefutable pattern")
-            } }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+            } },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -16779,13 +16817,15 @@ fn happyReduce_98() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 36, box happyReduction_98)
 }
 
-refute! { fn happyReduction_98<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_98<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
                 rshift_monad(
                     doDeclIdent(happy_var_1.clone(), declr.clone()),
                     withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
-            }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+            }) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -16794,13 +16834,15 @@ fn happyReduce_99() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 36, box happyReduction_99)
 }
 
-refute! { fn happyReduction_99<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_99<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
                 rshift_monad(
                     doDeclIdent(happy_var_1.clone(), declr.clone()),
                     withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
-            }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+            }) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -16809,7 +16851,8 @@ fn happyReduce_100() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 36, box happyReduction_100)
 }
 
-refute! { fn happyReduction_100<T>(HappyStk(HappyAbsSyn94(happy_var_6), Some(box HappyStk(HappyAbsSyn35(happy_var_5), Some(box HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_100<T>(HappyStk(HappyAbsSyn94(happy_var_6), Some(box HappyStk(HappyAbsSyn35(happy_var_5), Some(box HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             if let CDecl(declspecs, dies, at) = happy_var_1 {
                 let (f, s) = happy_var_5;
@@ -16821,7 +16864,8 @@ refute! { fn happyReduction_100<T>(HappyStk(HappyAbsSyn94(happy_var_6), Some(box
                 })
             } else {
                 panic!("irrefutable pattern")
-            } }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+            } },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -17022,8 +17066,10 @@ fn happyReduce_117() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 41, box happyReduction_117)
 }
 
-refute! { fn happyReduction_117<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CTypedef)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
+refute! {
+fn happyReduction_117<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CTypedef)) },
+              box move |r| happyReturn(HappyAbsSyn41(r)))
 }
 }
 
@@ -17032,8 +17078,10 @@ fn happyReduce_118() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 41, box happyReduction_118)
 }
 
-refute! { fn happyReduction_118<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CExtern)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
+refute! {
+fn happyReduction_118<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CExtern)) },
+              box move |r| happyReturn(HappyAbsSyn41(r)))
 }
 }
 
@@ -17042,8 +17090,10 @@ fn happyReduce_119() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 41, box happyReduction_119)
 }
 
-refute! { fn happyReduction_119<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CStatic)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
+refute! {
+fn happyReduction_119<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CStatic)) },
+              box move |r| happyReturn(HappyAbsSyn41(r)))
 }
 }
 
@@ -17052,8 +17102,10 @@ fn happyReduce_120() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 41, box happyReduction_120)
 }
 
-refute! { fn happyReduction_120<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAuto)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
+refute! {
+fn happyReduction_120<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAuto)) },
+              box move |r| happyReturn(HappyAbsSyn41(r)))
 }
 }
 
@@ -17062,8 +17114,10 @@ fn happyReduce_121() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 41, box happyReduction_121)
 }
 
-refute! { fn happyReduction_121<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CRegister)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
+refute! {
+fn happyReduction_121<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CRegister)) },
+              box move |r| happyReturn(HappyAbsSyn41(r)))
 }
 }
 
@@ -17072,8 +17126,10 @@ fn happyReduce_122() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 41, box happyReduction_122)
 }
 
-refute! { fn happyReduction_122<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CThread)) }, (box move |r| { happyReturn(HappyAbsSyn41(r)) }))
+refute! {
+fn happyReduction_122<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CThread)) },
+              box move |r| happyReturn(HappyAbsSyn41(r)))
 }
 }
 
@@ -17082,8 +17138,10 @@ fn happyReduce_123() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 42, box happyReduction_123)
 }
 
-refute! { fn happyReduction_123<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CInlineQual)) }, (box move |r| { happyReturn(HappyAbsSyn42(r)) }))
+refute! {
+fn happyReduction_123<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CInlineQual)) },
+              box move |r| happyReturn(HappyAbsSyn42(r)))
 }
 }
 
@@ -17092,8 +17150,10 @@ fn happyReduce_124() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 42, box happyReduction_124)
 }
 
-refute! { fn happyReduction_124<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CNoreturnQual)) }, (box move |r| { happyReturn(HappyAbsSyn42(r)) }))
+refute! {
+fn happyReduction_124<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CNoreturnQual)) },
+              box move |r| happyReturn(HappyAbsSyn42(r)))
 }
 }
 
@@ -17102,8 +17162,10 @@ fn happyReduce_125() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 43, box happyReduction_125)
 }
 
-refute! { fn happyReduction_125<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAlignAsType, happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn43(r)) }))
+refute! {
+fn happyReduction_125<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAlignAsType, happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn43(r)))
 }
 }
 
@@ -17112,8 +17174,10 @@ fn happyReduce_126() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 43, box happyReduction_126)
 }
 
-refute! { fn happyReduction_126<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAlignAsExpr, happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn43(r)) }))
+refute! {
+fn happyReduction_126<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAlignAsExpr, happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn43(r)))
 }
 }
 
@@ -17158,8 +17222,10 @@ fn happyReduce_130() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 45, box happyReduction_130)
 }
 
-refute! { fn happyReduction_130<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CVoidType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+refute! {
+fn happyReduction_130<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CVoidType)) },
+              box move |r| happyReturn(HappyAbsSyn45(r)))
 }
 }
 
@@ -17168,8 +17234,10 @@ fn happyReduce_131() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 45, box happyReduction_131)
 }
 
-refute! { fn happyReduction_131<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCharType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+refute! {
+fn happyReduction_131<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCharType)) },
+              box move |r| happyReturn(HappyAbsSyn45(r)))
 }
 }
 
@@ -17178,8 +17246,10 @@ fn happyReduce_132() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 45, box happyReduction_132)
 }
 
-refute! { fn happyReduction_132<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CShortType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+refute! {
+fn happyReduction_132<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CShortType)) },
+              box move |r| happyReturn(HappyAbsSyn45(r)))
 }
 }
 
@@ -17188,8 +17258,10 @@ fn happyReduce_133() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 45, box happyReduction_133)
 }
 
-refute! { fn happyReduction_133<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CIntType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+refute! {
+fn happyReduction_133<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CIntType)) },
+              box move |r| happyReturn(HappyAbsSyn45(r)))
 }
 }
 
@@ -17198,8 +17270,10 @@ fn happyReduce_134() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 45, box happyReduction_134)
 }
 
-refute! { fn happyReduction_134<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CLongType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+refute! {
+fn happyReduction_134<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CLongType)) },
+              box move |r| happyReturn(HappyAbsSyn45(r)))
 }
 }
 
@@ -17208,8 +17282,10 @@ fn happyReduce_135() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 45, box happyReduction_135)
 }
 
-refute! { fn happyReduction_135<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CFloatType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+refute! {
+fn happyReduction_135<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CFloatType)) },
+              box move |r| happyReturn(HappyAbsSyn45(r)))
 }
 }
 
@@ -17218,8 +17294,10 @@ fn happyReduce_136() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 45, box happyReduction_136)
 }
 
-refute! { fn happyReduction_136<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CDoubleType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+refute! {
+fn happyReduction_136<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CDoubleType)) },
+              box move |r| happyReturn(HappyAbsSyn45(r)))
 }
 }
 
@@ -17228,8 +17306,10 @@ fn happyReduce_137() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 45, box happyReduction_137)
 }
 
-refute! { fn happyReduction_137<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CSignedType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+refute! {
+fn happyReduction_137<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CSignedType)) },
+              box move |r| happyReturn(HappyAbsSyn45(r)))
 }
 }
 
@@ -17238,8 +17318,10 @@ fn happyReduce_138() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 45, box happyReduction_138)
 }
 
-refute! { fn happyReduction_138<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CUnsigType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+refute! {
+fn happyReduction_138<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CUnsigType)) },
+              box move |r| happyReturn(HappyAbsSyn45(r)))
 }
 }
 
@@ -17248,8 +17330,10 @@ fn happyReduce_139() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 45, box happyReduction_139)
 }
 
-refute! { fn happyReduction_139<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CBoolType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+refute! {
+fn happyReduction_139<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CBoolType)) },
+              box move |r| happyReturn(HappyAbsSyn45(r)))
 }
 }
 
@@ -17258,8 +17342,10 @@ fn happyReduce_140() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 45, box happyReduction_140)
 }
 
-refute! { fn happyReduction_140<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CComplexType)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+refute! {
+fn happyReduction_140<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CComplexType)) },
+              box move |r| happyReturn(HappyAbsSyn45(r)))
 }
 }
 
@@ -17268,8 +17354,10 @@ fn happyReduce_141() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 45, box happyReduction_141)
 }
 
-refute! { fn happyReduction_141<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CInt128Type)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+refute! {
+fn happyReduction_141<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CInt128Type)) },
+              box move |r| happyReturn(HappyAbsSyn45(r)))
 }
 }
 
@@ -17554,8 +17642,10 @@ fn happyReduce_165() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 50, box happyReduction_165)
 }
 
-refute! { fn happyReduction_165<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_2)), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| snoc(happy_var_1, CTypeSpec(CTypeDef(happy_var_2, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+refute! {
+fn happyReduction_165<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_2)), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| snoc(happy_var_1, CTypeSpec(CTypeDef(happy_var_2, at)))) },
+              box move |r| happyReturn(HappyAbsSyn38(r)))
 }
 }
 
@@ -17564,8 +17654,10 @@ fn happyReduce_166() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 50, box happyReduction_166)
 }
 
-refute! { fn happyReduction_166<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2, box |at| snoc(happy_var_1, CTypeSpec(CTypeOfExpr(happy_var_4, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+refute! {
+fn happyReduction_166<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_2, box |at| snoc(happy_var_1, CTypeSpec(CTypeOfExpr(happy_var_4, at)))) },
+              box move |r| happyReturn(HappyAbsSyn38(r)))
 }
 }
 
@@ -17574,8 +17666,10 @@ fn happyReduce_167() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 50, box happyReduction_167)
 }
 
-refute! { fn happyReduction_167<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2, box |at| snoc(happy_var_1, CTypeSpec(CTypeOfType(happy_var_4, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+refute! {
+fn happyReduction_167<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_2, box |at| snoc(happy_var_1, CTypeSpec(CTypeOfType(happy_var_4, at)))) },
+              box move |r| happyReturn(HappyAbsSyn38(r)))
 }
 }
 
@@ -17608,8 +17702,10 @@ fn happyReduce_170() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 51, box happyReduction_170)
 }
 
-refute! { fn happyReduction_170<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_1)), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box |at| singleton(CTypeSpec(CTypeDef(happy_var_1, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+refute! {
+fn happyReduction_170<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_1)), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), box |at| singleton(CTypeSpec(CTypeDef(happy_var_1, at)))) },
+              box move |r| happyReturn(HappyAbsSyn38(r)))
 }
 }
 
@@ -17618,8 +17714,10 @@ fn happyReduce_171() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 51, box happyReduction_171)
 }
 
-refute! { fn happyReduction_171<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, box |at| singleton(CTypeSpec(CTypeOfExpr(happy_var_3, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+refute! {
+fn happyReduction_171<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, box |at| singleton(CTypeSpec(CTypeOfExpr(happy_var_3, at)))) },
+              box move |r| happyReturn(HappyAbsSyn38(r)))
 }
 }
 
@@ -17628,8 +17726,10 @@ fn happyReduce_172() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 51, box happyReduction_172)
 }
 
-refute! { fn happyReduction_172<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, box |at| singleton(CTypeSpec(CTypeOfType(happy_var_3, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+refute! {
+fn happyReduction_172<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, box |at| singleton(CTypeSpec(CTypeOfType(happy_var_3, at)))) },
+              box move |r| happyReturn(HappyAbsSyn38(r)))
 }
 }
 
@@ -17638,8 +17738,10 @@ fn happyReduce_173() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 51, box happyReduction_173)
 }
 
-refute! { fn happyReduction_173<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_2)), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| snoc(rmap(CTypeQual, happy_var_1), CTypeSpec(CTypeDef(happy_var_2, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+refute! {
+fn happyReduction_173<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_2)), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| snoc(rmap(CTypeQual, happy_var_1), CTypeSpec(CTypeDef(happy_var_2, at)))) },
+              box move |r| happyReturn(HappyAbsSyn38(r)))
 }
 }
 
@@ -17648,8 +17750,10 @@ fn happyReduce_174() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 51, box happyReduction_174)
 }
 
-refute! { fn happyReduction_174<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2, box |at| snoc(rmap(CTypeQual, happy_var_1), CTypeSpec(CTypeOfExpr(happy_var_4, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+refute! {
+fn happyReduction_174<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_2, box |at| snoc(rmap(CTypeQual, happy_var_1), CTypeSpec(CTypeOfExpr(happy_var_4, at)))) },
+              box move |r| happyReturn(HappyAbsSyn38(r)))
 }
 }
 
@@ -17658,8 +17762,10 @@ fn happyReduce_175() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 51, box happyReduction_175)
 }
 
-refute! { fn happyReduction_175<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2, box |at| snoc(rmap(CTypeQual, happy_var_1), CTypeSpec(CTypeOfType(happy_var_4, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+refute! {
+fn happyReduction_175<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_2, box |at| snoc(rmap(CTypeQual, happy_var_1), CTypeSpec(CTypeOfType(happy_var_4, at)))) },
+              box move |r| happyReturn(HappyAbsSyn38(r)))
 }
 }
 
@@ -17668,8 +17774,10 @@ fn happyReduce_176() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 51, box happyReduction_176)
 }
 
-refute! { fn happyReduction_176<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_2)), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| snoc(reverseList(liftCAttrs(happy_var_1)), CTypeSpec(CTypeDef(happy_var_2, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+refute! {
+fn happyReduction_176<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_2)), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_2.clone(), box |at| snoc(reverseList(liftCAttrs(happy_var_1)), CTypeSpec(CTypeDef(happy_var_2, at)))) },
+              box move |r| happyReturn(HappyAbsSyn38(r)))
 }
 }
 
@@ -17678,8 +17786,10 @@ fn happyReduce_177() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 51, box happyReduction_177)
 }
 
-refute! { fn happyReduction_177<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box |at| snoc(reverseList(liftCAttrs(happy_var_1)), CTypeSpec(CTypeOfExpr(happy_var_4, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+refute! {
+fn happyReduction_177<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), box |at| snoc(reverseList(liftCAttrs(happy_var_1)), CTypeSpec(CTypeOfExpr(happy_var_4, at)))) },
+              box move |r| happyReturn(HappyAbsSyn38(r)))
 }
 }
 
@@ -17688,8 +17798,10 @@ fn happyReduce_178() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 51, box happyReduction_178)
 }
 
-refute! { fn happyReduction_178<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_2), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_2, box |at| snoc(reverseList(liftCAttrs(happy_var_1)), CTypeSpec(CTypeOfType(happy_var_4, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+refute! {
+fn happyReduction_178<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_2), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_2, box |at| snoc(reverseList(liftCAttrs(happy_var_1)), CTypeSpec(CTypeOfType(happy_var_4, at)))) },
+              box move |r| happyReturn(HappyAbsSyn38(r)))
 }
 }
 
@@ -17698,9 +17810,11 @@ fn happyReduce_179() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 51, box happyReduction_179)
 }
 
-refute! { fn happyReduction_179<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_3)), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_179<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_3)), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withNodeInfo(happy_var_3.clone(), box |at| snoc(rappend(rmap(CTypeQual, happy_var_1), liftCAttrs(happy_var_2)),
-                                                  CTypeSpec(CTypeDef(happy_var_3, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+                                                  CTypeSpec(CTypeDef(happy_var_3, at)))) },
+              box move |r| happyReturn(HappyAbsSyn38(r)))
 }
 }
 
@@ -17709,9 +17823,11 @@ fn happyReduce_180() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 51, box happyReduction_180)
 }
 
-refute! { fn happyReduction_180<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_180<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withNodeInfo(happy_var_3, box |at| snoc(rappend(rmap(CTypeQual, happy_var_1), liftCAttrs(happy_var_2)),
-                                          CTypeSpec(CTypeOfExpr(happy_var_5, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+                                          CTypeSpec(CTypeOfExpr(happy_var_5, at)))) },
+              box move |r| happyReturn(HappyAbsSyn38(r)))
 }
 }
 
@@ -17720,9 +17836,11 @@ fn happyReduce_181() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 51, box happyReduction_181)
 }
 
-refute! { fn happyReduction_181<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_181<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withNodeInfo(happy_var_3, box |at| snoc(rappend(rmap(CTypeQual, happy_var_1), liftCAttrs(happy_var_2)),
-                                          CTypeSpec(CTypeOfType(happy_var_5, at)))) }, (box move |r| { happyReturn(HappyAbsSyn38(r)) }))
+                                          CTypeSpec(CTypeOfType(happy_var_5, at)))) },
+              box move |r| happyReturn(HappyAbsSyn38(r)))
 }
 }
 
@@ -17755,8 +17873,10 @@ fn happyReduce_184() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 52, box happyReduction_184)
 }
 
-refute! { fn happyReduction_184<T>(HappyStk(HappyAbsSyn53(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CSUType, happy_var_1)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+refute! {
+fn happyReduction_184<T>(HappyStk(HappyAbsSyn53(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CSUType, happy_var_1)) },
+              box move |r| happyReturn(HappyAbsSyn45(r)))
 }
 }
 
@@ -17765,8 +17885,10 @@ fn happyReduce_185() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 52, box happyReduction_185)
 }
 
-refute! { fn happyReduction_185<T>(HappyStk(HappyAbsSyn61(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CEnumType, happy_var_1)) }, (box move |r| { happyReturn(HappyAbsSyn45(r)) }))
+refute! {
+fn happyReduction_185<T>(HappyStk(HappyAbsSyn61(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CEnumType, happy_var_1)) },
+              box move |r| happyReturn(HappyAbsSyn45(r)))
 }
 }
 
@@ -17775,8 +17897,10 @@ fn happyReduce_186() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 53, box happyReduction_186)
 }
 
-refute! { fn happyReduction_186<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn33(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn54(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CStructureUnion, unL(happy_var_1), Some(happy_var_3), Some(reverse(happy_var_5)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn53(r)) }))
+refute! {
+fn happyReduction_186<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn33(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn54(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CStructureUnion, unL(happy_var_1), Some(happy_var_3), Some(reverse(happy_var_5)), happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn53(r)))
 }
 }
 
@@ -17785,8 +17909,10 @@ fn happyReduce_187() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 53, box happyReduction_187)
 }
 
-refute! { fn happyReduction_187<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn33(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn54(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CStructureUnion, unL(happy_var_1), None,     Some(reverse(happy_var_4)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn53(r)) }))
+refute! {
+fn happyReduction_187<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn33(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn54(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CStructureUnion, unL(happy_var_1), None,     Some(reverse(happy_var_4)), happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn53(r)))
 }
 }
 
@@ -17795,8 +17921,10 @@ fn happyReduce_188() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 53, box happyReduction_188)
 }
 
-refute! { fn happyReduction_188<T>(HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn54(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CStructureUnion, unL(happy_var_1), Some(happy_var_3), None,              happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn53(r)) }))
+refute! {
+fn happyReduction_188<T>(HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn54(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CStructureUnion, unL(happy_var_1), Some(happy_var_3), None,              happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn53(r)))
 }
 }
 
@@ -17830,9 +17958,7 @@ fn happyReduce_191() -> ActionReturn {
 }
 
 fn happyReduction_191() -> HappyAbsSyn {
-    match () {
-        () => HappyAbsSyn33(empty()),
-    }
+    HappyAbsSyn33(empty())
 }
 
 
@@ -17908,12 +18034,14 @@ fn happyReduce_197() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 57, box happyReduction_197)
 }
 
-refute! { fn happyReduction_197<T>(HappyStk(HappyAbsSyn59(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_197<T>(HappyStk(HappyAbsSyn59(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             withNodeInfo(happy_var_1.clone(), match happy_var_3 {
                 (d, s) => partial_1!(CDecl, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)),
                                      vec![(d, None, s)])
-            }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+            }) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -17922,11 +18050,13 @@ fn happyReduce_198() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 57, box happyReduction_198)
 }
 
-refute! { fn happyReduction_198<T>(HappyStk(HappyAbsSyn59(happy_var_2), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_198<T>(HappyStk(HappyAbsSyn59(happy_var_2), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             withNodeInfo(happy_var_1.clone(), match happy_var_2 {
                 (d, s) => partial_1!(CDecl, liftCAttrs(happy_var_1), vec![(d, None, s)]),
-            }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+            }) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -17935,7 +18065,8 @@ fn happyReduce_199() -> ActionReturn {
     partial_5!(happyReduce, 4, 57, box happyReduction_199)
 }
 
-refute! { fn happyReduction_199(HappyStk(HappyAbsSyn59(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_199(HappyStk(HappyAbsSyn59(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn32(if let CDecl(declspecs, dies, at) = happy_var_1 {
                 match happy_var_4 {
                     (Some(d), s) => {
@@ -17956,7 +18087,8 @@ fn happyReduce_200() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 58, box happyReduction_200)
 }
 
-refute! { fn happyReduction_200<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn59(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_200<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn59(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             withNodeInfo(happy_var_1.clone(), match happy_var_2 {
                 (Some(d), s) => {
@@ -17965,7 +18097,8 @@ refute! { fn happyReduction_200<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(bo
                 (None, s) => {
                     partial_1!(CDecl, happy_var_1, vec![(None, None, s)])
                 },
-            }) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+            }) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -17974,7 +18107,8 @@ fn happyReduce_201() -> ActionReturn {
     partial_5!(happyReduce, 5, 58, box happyReduction_201)
 }
 
-refute! { fn happyReduction_201(HappyStk(HappyAbsSyn132(happy_var_5), Some(box HappyStk(HappyAbsSyn59(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_201(HappyStk(HappyAbsSyn132(happy_var_5), Some(box HappyStk(HappyAbsSyn59(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn32(if let CDecl(declspecs, dies, at) = happy_var_1 {
                 match happy_var_4 {
                     (Some(d), s) => {
@@ -17996,8 +18130,10 @@ fn happyReduce_202() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 58, box happyReduction_202)
 }
 
-refute! { fn happyReduction_202<T>(HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+refute! {
+fn happyReduction_202<T>(HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -18094,8 +18230,10 @@ fn happyReduce_210() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 61, box happyReduction_210)
 }
 
-refute! { fn happyReduction_210<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn62(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CEnumeration, None, Some(reverse(happy_var_4)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn61(r)) }))
+refute! {
+fn happyReduction_210<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn62(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CEnumeration, None, Some(reverse(happy_var_4)), happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn61(r)))
 }
 }
 
@@ -18104,8 +18242,10 @@ fn happyReduce_211() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 61, box happyReduction_211)
 }
 
-refute! { fn happyReduction_211<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn62(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CEnumeration, None, Some(reverse(happy_var_4)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn61(r)) }))
+refute! {
+fn happyReduction_211<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn62(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CEnumeration, None, Some(reverse(happy_var_4)), happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn61(r)))
 }
 }
 
@@ -18114,8 +18254,10 @@ fn happyReduce_212() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 61, box happyReduction_212)
 }
 
-refute! { fn happyReduction_212<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn62(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CEnumeration, Some(happy_var_3), Some(reverse(happy_var_5)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn61(r)) }))
+refute! {
+fn happyReduction_212<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn62(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CEnumeration, Some(happy_var_3), Some(reverse(happy_var_5)), happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn61(r)))
 }
 }
 
@@ -18124,8 +18266,10 @@ fn happyReduce_213() -> ActionReturn {
     partial_5!(happyMonadReduce, 7, 61, box happyReduction_213)
 }
 
-refute! { fn happyReduction_213<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn62(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CEnumeration, Some(happy_var_3), Some(reverse(happy_var_5)), happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn61(r)) }))
+refute! {
+fn happyReduction_213<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn62(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CEnumeration, Some(happy_var_3), Some(reverse(happy_var_5)), happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn61(r)))
 }
 }
 
@@ -18134,8 +18278,10 @@ fn happyReduce_214() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 61, box happyReduction_214)
 }
 
-refute! { fn happyReduction_214<T>(HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CEnumeration, Some(happy_var_3), None, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn61(r)) }))
+refute! {
+fn happyReduction_214<T>(HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CEnumeration, Some(happy_var_3), None, happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn61(r)))
 }
 }
 
@@ -18192,7 +18338,8 @@ fn happyReduce_219() -> ActionReturn {
     partial_5!(happyReduce, 4, 63, box happyReduction_219)
 }
 
-refute! { fn happyReduction_219(HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_219(HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn63((happy_var_1, Some(happy_var_4))), Some(box happyRest))
 }
 }
@@ -18214,8 +18361,10 @@ fn happyReduce_221() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 64, box happyReduction_221)
 }
 
-refute! { fn happyReduction_221<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CConstQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
+refute! {
+fn happyReduction_221<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CConstQual)) },
+              box move |r| happyReturn(HappyAbsSyn64(r)))
 }
 }
 
@@ -18224,8 +18373,10 @@ fn happyReduce_222() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 64, box happyReduction_222)
 }
 
-refute! { fn happyReduction_222<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CVolatQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
+refute! {
+fn happyReduction_222<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CVolatQual)) },
+              box move |r| happyReturn(HappyAbsSyn64(r)))
 }
 }
 
@@ -18234,8 +18385,10 @@ fn happyReduce_223() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 64, box happyReduction_223)
 }
 
-refute! { fn happyReduction_223<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CRestrQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
+refute! {
+fn happyReduction_223<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CRestrQual)) },
+              box move |r| happyReturn(HappyAbsSyn64(r)))
 }
 }
 
@@ -18244,8 +18397,10 @@ fn happyReduce_224() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 64, box happyReduction_224)
 }
 
-refute! { fn happyReduction_224<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CNullableQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
+refute! {
+fn happyReduction_224<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CNullableQual)) },
+              box move |r| happyReturn(HappyAbsSyn64(r)))
 }
 }
 
@@ -18254,8 +18409,10 @@ fn happyReduce_225() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 64, box happyReduction_225)
 }
 
-refute! { fn happyReduction_225<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CNonnullQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
+refute! {
+fn happyReduction_225<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CNonnullQual)) },
+              box move |r| happyReturn(HappyAbsSyn64(r)))
 }
 }
 
@@ -18264,8 +18421,10 @@ fn happyReduce_226() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 64, box happyReduction_226)
 }
 
-refute! { fn happyReduction_226<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAtomicQual)) }, (box move |r| { happyReturn(HappyAbsSyn64(r)) }))
+refute! {
+fn happyReduction_226<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAtomicQual)) },
+              box move |r| happyReturn(HappyAbsSyn64(r)))
 }
 }
 
@@ -18335,9 +18494,7 @@ fn happyReduce_232() -> ActionReturn {
 }
 
 fn happyReduction_232() -> HappyAbsSyn {
-    match () {
-        () => HappyAbsSyn67(None),
-    }
+    HappyAbsSyn67(None)
 }
 
 
@@ -18345,7 +18502,8 @@ fn happyReduce_233() -> ActionReturn {
     partial_5!(happyReduce, 4, 67, box happyReduction_233)
 }
 
-refute! { fn happyReduction_233(HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_233(HappyStk(_, Some(box HappyStk(HappyAbsSyn128(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn67(Some(happy_var_3)), Some(box happyRest))
 }
 }
@@ -18379,8 +18537,10 @@ fn happyReduce_236() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 69, box happyReduction_236)
 }
 
-refute! { fn happyReduction_236<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_1)), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(mkVarDeclr, happy_var_1)) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_236<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_1)), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(mkVarDeclr, happy_var_1)) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18389,8 +18549,10 @@ fn happyReduce_237() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 69, box happyReduction_237)
 }
 
-refute! { fn happyReduction_237<T>(HappyStk(HappyAbsSyn88(happy_var_2), Some(box HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_1)), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box move |at| { happy_var_2(mkVarDeclr(happy_var_1, at)) }) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_237<T>(HappyStk(HappyAbsSyn88(happy_var_2), Some(box HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_1)), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), box move |at| { happy_var_2(mkVarDeclr(happy_var_1, at)) }) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18423,8 +18585,10 @@ fn happyReduce_240() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 70, box happyReduction_240)
 }
 
-refute! { fn happyReduction_240<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_2, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_240<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_2, vec![])) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18433,8 +18597,10 @@ fn happyReduce_241() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 70, box happyReduction_241)
 }
 
-refute! { fn happyReduction_241<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_2, partial_1!(ptrDeclr, happy_var_3, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_241<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withAttribute(happy_var_1, happy_var_2, partial_1!(ptrDeclr, happy_var_3, vec![])) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18443,8 +18609,10 @@ fn happyReduce_242() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 70, box happyReduction_242)
 }
 
-refute! { fn happyReduction_242<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_242<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18453,8 +18621,10 @@ fn happyReduce_243() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 70, box happyReduction_243)
 }
 
-refute! { fn happyReduction_243<T>(HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_3, partial_1!(ptrDeclr, happy_var_4, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_243<T>(HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withAttribute(happy_var_1, happy_var_3, partial_1!(ptrDeclr, happy_var_4, reverse(happy_var_2))) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18475,7 +18645,8 @@ fn happyReduce_245() -> ActionReturn {
     partial_5!(happyReduce, 4, 71, box happyReduction_245)
 }
 
-refute! { fn happyReduction_245(HappyStk(HappyAbsSyn88(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_245(HappyStk(HappyAbsSyn88(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn66(happy_var_4(happy_var_2)), Some(box happyRest))
 }
 }
@@ -18485,7 +18656,8 @@ fn happyReduce_246() -> ActionReturn {
     partial_5!(happyReduce, 4, 71, box happyReduction_246)
 }
 
-refute! { fn happyReduction_246(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_246(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn66(appendDeclrAttrs(happy_var_2, happy_var_3)), Some(box happyRest))
 }
 }
@@ -18495,7 +18667,8 @@ fn happyReduce_247() -> ActionReturn {
     partial_5!(happyReduce, 5, 71, box happyReduction_247)
 }
 
-refute! { fn happyReduction_247(HappyStk(HappyAbsSyn88(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_247(HappyStk(HappyAbsSyn88(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn66(appendDeclrAttrs(happy_var_2, happy_var_5(happy_var_3))), Some(box happyRest))
 }
 }
@@ -18517,8 +18690,10 @@ fn happyReduce_249() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 72, box happyReduction_249)
 }
 
-refute! { fn happyReduction_249<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_249<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, vec![])) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18527,8 +18702,10 @@ fn happyReduce_250() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 72, box happyReduction_250)
 }
 
-refute! { fn happyReduction_250<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_4, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_250<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_4, reverse(happy_var_2))) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18537,8 +18714,10 @@ fn happyReduce_251() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 72, box happyReduction_251)
 }
 
-refute! { fn happyReduction_251<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_3, partial_1!(ptrDeclr, happy_var_5, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_251<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withAttribute(happy_var_1, happy_var_3, partial_1!(ptrDeclr, happy_var_5, reverse(happy_var_2))) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18547,8 +18726,10 @@ fn happyReduce_252() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 72, box happyReduction_252)
 }
 
-refute! { fn happyReduction_252<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_2, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_252<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_2, vec![])) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18557,8 +18738,10 @@ fn happyReduce_253() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 72, box happyReduction_253)
 }
 
-refute! { fn happyReduction_253<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_253<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18567,8 +18750,10 @@ fn happyReduce_254() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 72, box happyReduction_254)
 }
 
-refute! { fn happyReduction_254<T>(HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_3, partial_1!(ptrDeclr, happy_var_4, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_254<T>(HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withAttribute(happy_var_1, happy_var_3, partial_1!(ptrDeclr, happy_var_4, reverse(happy_var_2))) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18589,7 +18774,8 @@ fn happyReduce_256() -> ActionReturn {
     partial_5!(happyReduce, 4, 73, box happyReduction_256)
 }
 
-refute! { fn happyReduction_256(HappyStk(_, Some(box HappyStk(HappyAbsSyn88(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_256(HappyStk(_, Some(box HappyStk(HappyAbsSyn88(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn66(happy_var_3(happy_var_2)), Some(box happyRest))
 }
 }
@@ -18599,7 +18785,8 @@ fn happyReduce_257() -> ActionReturn {
     partial_5!(happyReduce, 4, 73, box happyReduction_257)
 }
 
-refute! { fn happyReduction_257(HappyStk(HappyAbsSyn88(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_257(HappyStk(HappyAbsSyn88(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn66(happy_var_4(happy_var_2)), Some(box happyRest))
 }
 }
@@ -18609,8 +18796,10 @@ fn happyReduce_258() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 74, box happyReduction_258)
 }
 
-refute! { fn happyReduction_258<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_1)), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(mkVarDeclr, happy_var_1)) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_258<T>(HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_1)), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(mkVarDeclr, happy_var_1)) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18667,8 +18856,10 @@ fn happyReduce_263() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 76, box happyReduction_263)
 }
 
-refute! { fn happyReduction_263<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_2, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_263<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_2, vec![])) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18677,8 +18868,10 @@ fn happyReduce_264() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 76, box happyReduction_264)
 }
 
-refute! { fn happyReduction_264<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_2, partial_1!(ptrDeclr, happy_var_3, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_264<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withAttribute(happy_var_1, happy_var_2, partial_1!(ptrDeclr, happy_var_3, vec![])) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18687,8 +18880,10 @@ fn happyReduce_265() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 76, box happyReduction_265)
 }
 
-refute! { fn happyReduction_265<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_265<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18697,8 +18892,10 @@ fn happyReduce_266() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 76, box happyReduction_266)
 }
 
-refute! { fn happyReduction_266<T>(HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_3, partial_1!(ptrDeclr, happy_var_4, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_266<T>(HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withAttribute(happy_var_1, happy_var_3, partial_1!(ptrDeclr, happy_var_4, reverse(happy_var_2))) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18731,7 +18928,8 @@ fn happyReduce_269() -> ActionReturn {
     partial_5!(happyReduce, 4, 77, box happyReduction_269)
 }
 
-refute! { fn happyReduction_269(HappyStk(HappyAbsSyn88(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_269(HappyStk(HappyAbsSyn88(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn66(happy_var_4(happy_var_2)), Some(box happyRest))
 }
 }
@@ -18741,7 +18939,8 @@ fn happyReduce_270() -> ActionReturn {
     partial_5!(happyReduce, 4, 77, box happyReduction_270)
 }
 
-refute! { fn happyReduction_270(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_270(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn66(appendDeclrAttrs(happy_var_2, happy_var_3)), Some(box happyRest))
 }
 }
@@ -18751,7 +18950,8 @@ fn happyReduce_271() -> ActionReturn {
     partial_5!(happyReduce, 5, 77, box happyReduction_271)
 }
 
-refute! { fn happyReduction_271(HappyStk(HappyAbsSyn88(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_271(HappyStk(HappyAbsSyn88(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn66(appendDeclrAttrs(happy_var_2, happy_var_5(happy_var_3))), Some(box happyRest))
 }
 }
@@ -18761,8 +18961,10 @@ fn happyReduce_272() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 78, box happyReduction_272)
 }
 
-refute! { fn happyReduction_272<T>(HappyStk(HappyTerminal(CTokIdent(_, happy_var_1)), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(mkVarDeclr, happy_var_1)) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_272<T>(HappyStk(HappyTerminal(CTokIdent(_, happy_var_1)), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(mkVarDeclr, happy_var_1)) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18783,7 +18985,8 @@ fn happyReduce_274() -> ActionReturn {
     partial_5!(happyReduce, 4, 78, box happyReduction_274)
 }
 
-refute! { fn happyReduction_274(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_274(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn66(appendDeclrAttrs(happy_var_2, happy_var_3)), Some(box happyRest))
 }
 }
@@ -18817,8 +19020,10 @@ fn happyReduce_277() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 80, box happyReduction_277)
 }
 
-refute! { fn happyReduction_277<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_2, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_277<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_2, vec![])) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18827,8 +19032,10 @@ fn happyReduce_278() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 80, box happyReduction_278)
 }
 
-refute! { fn happyReduction_278<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_278<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18837,8 +19044,10 @@ fn happyReduce_279() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 81, box happyReduction_279)
 }
 
-refute! { fn happyReduction_279<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn21(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(funDeclr, happy_var_1, Left(reverse(happy_var_3)), vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_279<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn21(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(funDeclr, happy_var_1, Left(reverse(happy_var_3)), vec![])) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -18859,7 +19068,8 @@ fn happyReduce_281() -> ActionReturn {
     partial_5!(happyReduce, 4, 81, box happyReduction_281)
 }
 
-refute! { fn happyReduction_281(HappyStk(HappyAbsSyn88(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_281(HappyStk(HappyAbsSyn88(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn66(happy_var_4(happy_var_2)), Some(box happyRest))
 }
 }
@@ -18870,9 +19080,7 @@ fn happyReduce_282() -> ActionReturn {
 }
 
 fn happyReduction_282() -> HappyAbsSyn {
-    match () {
-        () => HappyAbsSyn82((vec![], false)),
-    }
+    HappyAbsSyn82((vec![], false))
 }
 
 
@@ -18928,8 +19136,10 @@ fn happyReduce_287() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 84, box happyReduction_287)
 }
 
-refute! { fn happyReduction_287<T>(HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+refute! {
+fn happyReduction_287<T>(HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -18938,8 +19148,10 @@ fn happyReduce_288() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 84, box happyReduction_288)
 }
 
-refute! { fn happyReduction_288<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![(Some(reverseDeclr(happy_var_2)), None, None)])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+refute! {
+fn happyReduction_288<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![(Some(reverseDeclr(happy_var_2)), None, None)])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -18948,9 +19160,11 @@ fn happyReduce_289() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 84, box happyReduction_289)
 }
 
-refute! { fn happyReduction_289<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_289<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1,
-                                               vec![(Some(reverseDeclr(appendDeclrAttrs(happy_var_3, happy_var_2))), None, None)])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+                                               vec![(Some(reverseDeclr(appendDeclrAttrs(happy_var_3, happy_var_2))), None, None)])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -18959,9 +19173,11 @@ fn happyReduce_290() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 84, box happyReduction_290)
 }
 
-refute! { fn happyReduction_290<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_290<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1,
-                                               vec![(Some(reverseDeclr(appendDeclrAttrs(happy_var_3, happy_var_2))), None, None)])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+                                               vec![(Some(reverseDeclr(appendDeclrAttrs(happy_var_3, happy_var_2))), None, None)])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -18970,8 +19186,10 @@ fn happyReduce_291() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 84, box happyReduction_291)
 }
 
-refute! { fn happyReduction_291<T>(HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, reverse(happy_var_1), vec![])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+refute! {
+fn happyReduction_291<T>(HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, reverse(happy_var_1), vec![])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -18980,8 +19198,10 @@ fn happyReduce_292() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 84, box happyReduction_292)
 }
 
-refute! { fn happyReduction_292<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, reverse(happy_var_1), vec![(Some(reverseDeclr(happy_var_2)), None, None)])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+refute! {
+fn happyReduction_292<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, reverse(happy_var_1), vec![(Some(reverseDeclr(happy_var_2)), None, None)])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -18990,9 +19210,11 @@ fn happyReduce_293() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 84, box happyReduction_293)
 }
 
-refute! { fn happyReduction_293<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_293<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, reverse(happy_var_1),
-                                               vec![(Some(reverseDeclr(appendDeclrAttrs(happy_var_3, happy_var_2))), None, None)])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+                                               vec![(Some(reverseDeclr(appendDeclrAttrs(happy_var_3, happy_var_2))), None, None)])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -19001,8 +19223,10 @@ fn happyReduce_294() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 84, box happyReduction_294)
 }
 
-refute! { fn happyReduction_294<T>(HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+refute! {
+fn happyReduction_294<T>(HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -19011,8 +19235,10 @@ fn happyReduce_295() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 84, box happyReduction_295)
 }
 
-refute! { fn happyReduction_295<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![(Some(reverseDeclr(happy_var_2)), None, None)])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+refute! {
+fn happyReduction_295<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![(Some(reverseDeclr(happy_var_2)), None, None)])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -19021,9 +19247,11 @@ fn happyReduce_296() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 84, box happyReduction_296)
 }
 
-refute! { fn happyReduction_296<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_296<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1,
-                                               vec![(Some(reverseDeclr(appendDeclrAttrs(happy_var_3, happy_var_2))), None, None)])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+                                               vec![(Some(reverseDeclr(appendDeclrAttrs(happy_var_3, happy_var_2))), None, None)])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -19032,9 +19260,11 @@ fn happyReduce_297() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 84, box happyReduction_297)
 }
 
-refute! { fn happyReduction_297<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_297<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1,
-                                               vec![(Some(reverseDeclr(appendDeclrAttrs(happy_var_3, happy_var_2))), None, None)])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+                                               vec![(Some(reverseDeclr(appendDeclrAttrs(happy_var_3, happy_var_2))), None, None)])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -19043,8 +19273,10 @@ fn happyReduce_298() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 84, box happyReduction_298)
 }
 
-refute! { fn happyReduction_298<T>(HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, liftTypeQuals(happy_var_1), vec![])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+refute! {
+fn happyReduction_298<T>(HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, liftTypeQuals(happy_var_1), vec![])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -19053,8 +19285,10 @@ fn happyReduce_299() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 84, box happyReduction_299)
 }
 
-refute! { fn happyReduction_299<T>(HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)), vec![])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+refute! {
+fn happyReduction_299<T>(HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)), vec![])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -19063,9 +19297,11 @@ fn happyReduce_300() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 84, box happyReduction_300)
 }
 
-refute! { fn happyReduction_300<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_300<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, liftTypeQuals(happy_var_1),
-                                               vec![(Some(reverseDeclr(happy_var_2)), None, None)])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+                                               vec![(Some(reverseDeclr(happy_var_2)), None, None)])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -19074,9 +19310,11 @@ fn happyReduce_301() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 84, box happyReduction_301)
 }
 
-refute! { fn happyReduction_301<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_301<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, liftTypeQuals(happy_var_1),
-                                               vec![(Some(reverseDeclr(appendDeclrAttrs(happy_var_3, happy_var_2))), None, None)])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+                                               vec![(Some(reverseDeclr(appendDeclrAttrs(happy_var_3, happy_var_2))), None, None)])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -19109,8 +19347,10 @@ fn happyReduce_304() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 86, box happyReduction_304)
 }
 
-refute! { fn happyReduction_304<T>(HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+refute! {
+fn happyReduction_304<T>(HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -19119,8 +19359,10 @@ fn happyReduce_305() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 86, box happyReduction_305)
 }
 
-refute! { fn happyReduction_305<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![(Some(reverseDeclr(happy_var_2)), None, None)])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+refute! {
+fn happyReduction_305<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![(Some(reverseDeclr(happy_var_2)), None, None)])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -19129,8 +19371,10 @@ fn happyReduce_306() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 86, box happyReduction_306)
 }
 
-refute! { fn happyReduction_306<T>(HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)), vec![])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+refute! {
+fn happyReduction_306<T>(HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)), vec![])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -19139,9 +19383,11 @@ fn happyReduce_307() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 86, box happyReduction_307)
 }
 
-refute! { fn happyReduction_307<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_307<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, liftTypeQuals(happy_var_1),
-                                               vec![(Some(reverseDeclr(happy_var_2)), None, None)])) }, (box move |r| { happyReturn(HappyAbsSyn32(r)) }))
+                                               vec![(Some(reverseDeclr(happy_var_2)), None, None)])) },
+              box move |r| happyReturn(HappyAbsSyn32(r)))
 }
 }
 
@@ -19198,7 +19444,8 @@ fn happyReduce_312() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 88, box happyReduction_312)
 }
 
-refute! { fn happyReduction_312<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn82(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_312<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn82(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             withNodeInfo(happy_var_1, box move |at: NodeInfo| {
                 let a: Rc<Box<Fn(CDeclrR) -> CDeclrR>> = Rc::new(box move |declr| {
@@ -19206,7 +19453,8 @@ refute! { fn happyReduction_312<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn82(h
                     funDeclr(declr, (Right((params, variadic))), vec![], at.clone())
                 });
                 a
-            }) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+            }) },
+              box move |r| happyReturn(HappyAbsSyn88(r)))
 }
 }
 
@@ -19239,14 +19487,16 @@ fn happyReduce_315() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 90, box happyReduction_315)
 }
 
-refute! { fn happyReduction_315<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_315<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             withNodeInfo(happy_var_1.clone(), box move |at: NodeInfo| {
                 let a: Rc<Box<Fn(CDeclrR) -> CDeclrR>> = Rc::new(box move |declr| {
                     arrDeclr(declr, vec![], false, false, happy_var_2.clone(), at.clone())
                 });
                 a
-            }) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+            }) },
+              box move |r| happyReturn(HappyAbsSyn88(r)))
 }
 }
 
@@ -19255,9 +19505,11 @@ fn happyReduce_316() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 90, box happyReduction_316)
 }
 
-refute! { fn happyReduction_316<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_316<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withAttributePF(happy_var_1, happy_var_2, box move |at, declr|
-                           arrDeclr(declr, vec![], false, false, happy_var_3.clone(), at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+                           arrDeclr(declr, vec![], false, false, happy_var_3.clone(), at)) },
+              box move |r| happyReturn(HappyAbsSyn88(r)))
 }
 }
 
@@ -19266,14 +19518,16 @@ fn happyReduce_317() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 90, box happyReduction_317)
 }
 
-refute! { fn happyReduction_317<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_317<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             withNodeInfo(happy_var_1.clone(), box move |at: NodeInfo| {
                 let a: Rc<Box<Fn(CDeclrR) -> CDeclrR>> = Rc::new(
                     box move |declr| { arrDeclr(declr, reverse(happy_var_2.clone()),
                                                 false, false, happy_var_3.clone(), at.clone()) });
                 a
-            }) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+            }) },
+              box move |r| happyReturn(HappyAbsSyn88(r)))
 }
 }
 
@@ -19282,9 +19536,11 @@ fn happyReduce_318() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 90, box happyReduction_318)
 }
 
-refute! { fn happyReduction_318<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_318<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn124(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withAttributePF(happy_var_1, happy_var_3, box move |at, declr|
-                           arrDeclr(declr, reverse(happy_var_2.clone()), false, false, happy_var_4.clone(), at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+                           arrDeclr(declr, reverse(happy_var_2.clone()), false, false, happy_var_4.clone(), at)) },
+              box move |r| happyReturn(HappyAbsSyn88(r)))
 }
 }
 
@@ -19293,9 +19549,11 @@ fn happyReduce_319() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 90, box happyReduction_319)
 }
 
-refute! { fn happyReduction_319<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_319<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withAttributePF(happy_var_1, happy_var_3, box move |at, declr|
-                           arrDeclr(declr, vec![], false, true, Some(happy_var_4.clone()), at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+                           arrDeclr(declr, vec![], false, true, Some(happy_var_4.clone()), at)) },
+              box move |r| happyReturn(HappyAbsSyn88(r)))
 }
 }
 
@@ -19304,9 +19562,11 @@ fn happyReduce_320() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 90, box happyReduction_320)
 }
 
-refute! { fn happyReduction_320<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_5), Some(box HappyStk(HappyAbsSyn132(happy_var_4), Some(box HappyStk(HappyAbsSyn65(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_320<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_5), Some(box HappyStk(HappyAbsSyn132(happy_var_4), Some(box HappyStk(HappyAbsSyn65(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withAttributePF(happy_var_1, happy_var_4, box move |at, declr|
-                           arrDeclr(declr, reverse(happy_var_3.clone()), false, true, Some(happy_var_5.clone()), at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+                           arrDeclr(declr, reverse(happy_var_3.clone()), false, true, Some(happy_var_5.clone()), at)) },
+              box move |r| happyReturn(HappyAbsSyn88(r)))
 }
 }
 
@@ -19315,9 +19575,11 @@ fn happyReduce_321() -> ActionReturn {
     partial_5!(happyMonadReduce, 7, 90, box happyReduction_321)
 }
 
-refute! { fn happyReduction_321<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_6), Some(box HappyStk(HappyAbsSyn132(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_321<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_6), Some(box HappyStk(HappyAbsSyn132(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withAttributePF(happy_var_1, __op_addadd(happy_var_3, happy_var_5), box move |at, declr|
-                           arrDeclr(declr, reverse(happy_var_2.clone()), false, true, Some(happy_var_6.clone()), at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+                           arrDeclr(declr, reverse(happy_var_2.clone()), false, true, Some(happy_var_6.clone()), at)) },
+              box move |r| happyReturn(HappyAbsSyn88(r)))
 }
 }
 
@@ -19326,9 +19588,11 @@ fn happyReduce_322() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 90, box happyReduction_322)
 }
 
-refute! { fn happyReduction_322<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_322<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withAttributePF(happy_var_1, happy_var_3, box move |at, declr|
-                           arrDeclr(declr, vec![], true, false, None, at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+                           arrDeclr(declr, vec![], true, false, None, at)) },
+              box move |r| happyReturn(HappyAbsSyn88(r)))
 }
 }
 
@@ -19337,9 +19601,11 @@ fn happyReduce_323() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 90, box happyReduction_323)
 }
 
-refute! { fn happyReduction_323<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_323<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withAttributePF(happy_var_1, __op_addadd(happy_var_2, happy_var_4), box move |at, declr|
-                           arrDeclr(declr, vec![], true, false, None, at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+                           arrDeclr(declr, vec![], true, false, None, at)) },
+              box move |r| happyReturn(HappyAbsSyn88(r)))
 }
 }
 
@@ -19348,9 +19614,11 @@ fn happyReduce_324() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 90, box happyReduction_324)
 }
 
-refute! { fn happyReduction_324<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_324<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withAttributePF(happy_var_1, happy_var_4, box move |at, declr|
-                           arrDeclr(declr, reverse(happy_var_2.clone()), true, false, None, at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+                           arrDeclr(declr, reverse(happy_var_2.clone()), true, false, None, at)) },
+              box move |r| happyReturn(HappyAbsSyn88(r)))
 }
 }
 
@@ -19359,9 +19627,11 @@ fn happyReduce_325() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 90, box happyReduction_325)
 }
 
-refute! { fn happyReduction_325<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_325<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({ withAttributePF(happy_var_1, __op_addadd(happy_var_3, happy_var_5), box move |at, declr|
-                           arrDeclr(declr, reverse(happy_var_2.clone()), true, false, None, at)) }, (box move |r| { happyReturn(HappyAbsSyn88(r)) }))
+                           arrDeclr(declr, reverse(happy_var_2.clone()), true, false, None, at)) },
+              box move |r| happyReturn(HappyAbsSyn88(r)))
 }
 }
 
@@ -19370,8 +19640,10 @@ fn happyReduce_326() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 91, box happyReduction_326)
 }
 
-refute! { fn happyReduction_326<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, emptyDeclr(), vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_326<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, emptyDeclr(), vec![])) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -19380,8 +19652,10 @@ fn happyReduce_327() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 91, box happyReduction_327)
 }
 
-refute! { fn happyReduction_327<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_3, partial_1!(ptrDeclr, emptyDeclr(), reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_327<T>(HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withAttribute(happy_var_1, happy_var_3, partial_1!(ptrDeclr, emptyDeclr(), reverse(happy_var_2))) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -19390,8 +19664,10 @@ fn happyReduce_328() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 91, box happyReduction_328)
 }
 
-refute! { fn happyReduction_328<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_2, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_328<T>(HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_2, vec![])) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -19400,8 +19676,10 @@ fn happyReduce_329() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 91, box happyReduction_329)
 }
 
-refute! { fn happyReduction_329<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_329<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn65(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(ptrDeclr, happy_var_3, reverse(happy_var_2))) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -19410,8 +19688,10 @@ fn happyReduce_330() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 91, box happyReduction_330)
 }
 
-refute! { fn happyReduction_330<T>(HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_2, partial_1!(ptrDeclr, emptyDeclr(), vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_330<T>(HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withAttribute(happy_var_1, happy_var_2, partial_1!(ptrDeclr, emptyDeclr(), vec![])) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -19420,8 +19700,10 @@ fn happyReduce_331() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 91, box happyReduction_331)
 }
 
-refute! { fn happyReduction_331<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withAttribute(happy_var_1, happy_var_2, partial_1!(ptrDeclr, happy_var_3, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+refute! {
+fn happyReduction_331<T>(HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withAttribute(happy_var_1, happy_var_2, partial_1!(ptrDeclr, happy_var_3, vec![])) },
+              box move |r| happyReturn(HappyAbsSyn66(r)))
 }
 }
 
@@ -19466,7 +19748,8 @@ fn happyReduce_335() -> ActionReturn {
     partial_5!(happyReduce, 4, 92, box happyReduction_335)
 }
 
-refute! { fn happyReduction_335(HappyStk(HappyAbsSyn88(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_335(HappyStk(HappyAbsSyn88(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn66(happy_var_4(happy_var_2)), Some(box happyRest))
 }
 }
@@ -19476,7 +19759,8 @@ fn happyReduce_336() -> ActionReturn {
     partial_5!(happyReduce, 4, 92, box happyReduction_336)
 }
 
-refute! { fn happyReduction_336(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_336(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn66(appendDeclrAttrs(happy_var_2, happy_var_3)), Some(box happyRest))
 }
 }
@@ -19486,7 +19770,8 @@ fn happyReduce_337() -> ActionReturn {
     partial_5!(happyReduce, 4, 92, box happyReduction_337)
 }
 
-refute! { fn happyReduction_337(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_337(HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn66(appendDeclrAttrs(happy_var_2, happy_var_3)), Some(box happyRest))
 }
 }
@@ -19496,7 +19781,8 @@ fn happyReduce_338() -> ActionReturn {
     partial_5!(happyReduce, 4, 92, box happyReduction_338)
 }
 
-refute! { fn happyReduction_338(HappyStk(_, Some(box HappyStk(HappyAbsSyn88(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_338(HappyStk(_, Some(box HappyStk(HappyAbsSyn88(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn66(appendDeclrAttrs(happy_var_2, happy_var_3(emptyDeclr()))), Some(box happyRest))
 }
 }
@@ -19506,7 +19792,8 @@ fn happyReduce_339() -> ActionReturn {
     partial_5!(happyReduce, 5, 92, box happyReduction_339)
 }
 
-refute! { fn happyReduction_339(HappyStk(HappyAbsSyn88(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_339(HappyStk(HappyAbsSyn88(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(_, Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn66(appendDeclrAttrs(happy_var_2, happy_var_5(happy_var_3))), Some(box happyRest))
 }
 }
@@ -19528,8 +19815,10 @@ fn happyReduce_341() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 93, box happyReduction_341)
 }
 
-refute! { fn happyReduction_341<T>(HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CInitExpr, happy_var_1)) }, (box move |r| { happyReturn(HappyAbsSyn93(r)) }))
+refute! {
+fn happyReduction_341<T>(HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CInitExpr, happy_var_1)) },
+              box move |r| happyReturn(HappyAbsSyn93(r)))
 }
 }
 
@@ -19538,8 +19827,10 @@ fn happyReduce_342() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 93, box happyReduction_342)
 }
 
-refute! { fn happyReduction_342<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn95(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CInitList, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn93(r)) }))
+refute! {
+fn happyReduction_342<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn95(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CInitList, reverse(happy_var_2))) },
+              box move |r| happyReturn(HappyAbsSyn93(r)))
 }
 }
 
@@ -19548,8 +19839,10 @@ fn happyReduce_343() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 93, box happyReduction_343)
 }
 
-refute! { fn happyReduction_343<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn95(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CInitList, reverse(happy_var_2))) }, (box move |r| { happyReturn(HappyAbsSyn93(r)) }))
+refute! {
+fn happyReduction_343<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn95(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CInitList, reverse(happy_var_2))) },
+              box move |r| happyReturn(HappyAbsSyn93(r)))
 }
 }
 
@@ -19559,9 +19852,7 @@ fn happyReduce_344() -> ActionReturn {
 }
 
 fn happyReduction_344() -> HappyAbsSyn {
-    match () {
-        () => HappyAbsSyn94(None),
-    }
+    HappyAbsSyn94(None)
 }
 
 
@@ -19582,9 +19873,7 @@ fn happyReduce_346() -> ActionReturn {
 }
 
 fn happyReduction_346() -> HappyAbsSyn {
-    match () {
-        () => HappyAbsSyn95(empty()),
-    }
+    HappyAbsSyn95(empty())
 }
 
 
@@ -19628,7 +19917,8 @@ fn happyReduce_350() -> ActionReturn {
     partial_5!(happyReduce, 4, 95, box happyReduction_350)
 }
 
-refute! { fn happyReduction_350(HappyStk(HappyAbsSyn93(happy_var_4), Some(box HappyStk(HappyAbsSyn96(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn95(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_350(HappyStk(HappyAbsSyn93(happy_var_4), Some(box HappyStk(HappyAbsSyn96(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn95(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn95(snoc(happy_var_1, (happy_var_3, happy_var_4))), Some(box happyRest))
 }
 }
@@ -19650,8 +19940,10 @@ fn happyReduce_352() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 96, box happyReduction_352)
 }
 
-refute! { fn happyReduction_352<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box |_0| vec![CMemberDesig(happy_var_1, _0)]) }, (box move |r| { happyReturn(HappyAbsSyn96(r)) }))
+refute! {
+fn happyReduction_352<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn131(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), box |_0| vec![CMemberDesig(happy_var_1, _0)]) },
+              box move |r| happyReturn(HappyAbsSyn96(r)))
 }
 }
 
@@ -19696,8 +19988,10 @@ fn happyReduce_356() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 98, box happyReduction_356)
 }
 
-refute! { fn happyReduction_356<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CArrDesig, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn98(r)) }))
+refute! {
+fn happyReduction_356<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CArrDesig, happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn98(r)))
 }
 }
 
@@ -19706,8 +20000,10 @@ fn happyReduce_357() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 98, box happyReduction_357)
 }
 
-refute! { fn happyReduction_357<T>(HappyStk(HappyAbsSyn131(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CMemberDesig, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn98(r)) }))
+refute! {
+fn happyReduction_357<T>(HappyStk(HappyAbsSyn131(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CMemberDesig, happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn98(r)))
 }
 }
 
@@ -19728,8 +20024,10 @@ fn happyReduce_359() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 99, box happyReduction_359)
 }
 
-refute! { fn happyReduction_359<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CRangeDesig, happy_var_2, happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn98(r)) }))
+refute! {
+fn happyReduction_359<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CRangeDesig, happy_var_2, happy_var_4)) },
+              box move |r| happyReturn(HappyAbsSyn98(r)))
 }
 }
 
@@ -19738,8 +20036,10 @@ fn happyReduce_360() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 100, box happyReduction_360)
 }
 
-refute! { fn happyReduction_360<T>(HappyStk(HappyTerminal(CTokIdent(_, happy_var_1)), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CVar, happy_var_1)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_360<T>(HappyStk(HappyTerminal(CTokIdent(_, happy_var_1)), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CVar, happy_var_1)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -19784,8 +20084,10 @@ fn happyReduce_364() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 100, box happyReduction_364)
 }
 
-refute! { fn happyReduction_364<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn101(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CGenericSelection, box happy_var_3, reverse(happy_var_5))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_364<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn101(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CGenericSelection, box happy_var_3, reverse(happy_var_5))) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -19794,8 +20096,10 @@ fn happyReduce_365() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 100, box happyReduction_365)
 }
 
-refute! { fn happyReduction_365<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn12(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CStatExpr, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_365<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn12(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CStatExpr, box happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -19804,8 +20108,10 @@ fn happyReduce_366() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 100, box happyReduction_366)
 }
 
-refute! { fn happyReduction_366<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, box move |_0| CBuiltinExpr(box CBuiltinVaArg(happy_var_3, happy_var_5, _0))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_366<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, box move |_0| CBuiltinExpr(box CBuiltinVaArg(happy_var_3, happy_var_5, _0))) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -19814,8 +20120,10 @@ fn happyReduce_367() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 100, box happyReduction_367)
 }
 
-refute! { fn happyReduction_367<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn97(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, box move |_0| CBuiltinExpr(box CBuiltinOffsetOf(happy_var_3, reverse(happy_var_5), _0))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_367<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn97(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, box move |_0| CBuiltinExpr(box CBuiltinOffsetOf(happy_var_3, reverse(happy_var_5), _0))) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -19824,8 +20132,10 @@ fn happyReduce_368() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 100, box happyReduction_368)
 }
 
-refute! { fn happyReduction_368<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, box move |_0| CBuiltinExpr(box CBuiltinTypesCompatible(happy_var_3, happy_var_5, _0))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_368<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, box move |_0| CBuiltinExpr(box CBuiltinTypesCompatible(happy_var_3, happy_var_5, _0))) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -19882,8 +20192,10 @@ fn happyReduce_373() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 103, box happyReduction_373)
 }
 
-refute! { fn happyReduction_373<T>(HappyStk(HappyAbsSyn131(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| singleton(CMemberDesig(happy_var_1, _0))) }, (box move |r| { happyReturn(HappyAbsSyn97(r)) }))
+refute! {
+fn happyReduction_373<T>(HappyStk(HappyAbsSyn131(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| singleton(CMemberDesig(happy_var_1, _0))) },
+              box move |r| happyReturn(HappyAbsSyn97(r)))
 }
 }
 
@@ -19892,8 +20204,10 @@ fn happyReduce_374() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 103, box happyReduction_374)
 }
 
-refute! { fn happyReduction_374<T>(HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn97(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_3.clone(), box move |_0| snoc(happy_var_1, CMemberDesig(happy_var_3, _0))) }, (box move |r| { happyReturn(HappyAbsSyn97(r)) }))
+refute! {
+fn happyReduction_374<T>(HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn97(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_3.clone(), box move |_0| snoc(happy_var_1, CMemberDesig(happy_var_3, _0))) },
+              box move |r| happyReturn(HappyAbsSyn97(r)))
 }
 }
 
@@ -19902,8 +20216,10 @@ fn happyReduce_375() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 103, box happyReduction_375)
 }
 
-refute! { fn happyReduction_375<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn97(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_3.clone(), box move |_0| snoc(happy_var_1, CArrDesig(happy_var_3, _0))) }, (box move |r| { happyReturn(HappyAbsSyn97(r)) }))
+refute! {
+fn happyReduction_375<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn97(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_3.clone(), box move |_0| snoc(happy_var_1, CArrDesig(happy_var_3, _0))) },
+              box move |r| happyReturn(HappyAbsSyn97(r)))
 }
 }
 
@@ -19924,8 +20240,10 @@ fn happyReduce_377() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 104, box happyReduction_377)
 }
 
-refute! { fn happyReduction_377<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CIndex, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_377<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CIndex, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -19934,8 +20252,10 @@ fn happyReduce_378() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 104, box happyReduction_378)
 }
 
-refute! { fn happyReduction_378<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCall, box happy_var_1, vec![])) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_378<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCall, box happy_var_1, vec![])) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -19944,8 +20264,10 @@ fn happyReduce_379() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 104, box happyReduction_379)
 }
 
-refute! { fn happyReduction_379<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn105(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCall, box happy_var_1, reverse(happy_var_3))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_379<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn105(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCall, box happy_var_1, reverse(happy_var_3))) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -19954,8 +20276,10 @@ fn happyReduce_380() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 104, box happyReduction_380)
 }
 
-refute! { fn happyReduction_380<T>(HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CMember, box happy_var_1, happy_var_3, false)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_380<T>(HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CMember, box happy_var_1, happy_var_3, false)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -19964,8 +20288,10 @@ fn happyReduce_381() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 104, box happyReduction_381)
 }
 
-refute! { fn happyReduction_381<T>(HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CMember, box happy_var_1, happy_var_3, true)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_381<T>(HappyStk(HappyAbsSyn131(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CMember, box happy_var_1, happy_var_3, true)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -19974,8 +20300,10 @@ fn happyReduce_382() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 104, box happyReduction_382)
 }
 
-refute! { fn happyReduction_382<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CUnary, CPostIncOp, box happy_var_1)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_382<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CUnary, CPostIncOp, box happy_var_1)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -19984,8 +20312,10 @@ fn happyReduce_383() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 104, box happyReduction_383)
 }
 
-refute! { fn happyReduction_383<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CUnary, CPostDecOp, box happy_var_1)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_383<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CUnary, CPostDecOp, box happy_var_1)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -19994,8 +20324,10 @@ fn happyReduce_384() -> ActionReturn {
     partial_5!(happyMonadReduce, 6, 104, box happyReduction_384)
 }
 
-refute! { fn happyReduction_384<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn95(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCompoundLit, box happy_var_2, reverse(happy_var_5))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_384<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn95(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCompoundLit, box happy_var_2, reverse(happy_var_5))) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20004,8 +20336,10 @@ fn happyReduce_385() -> ActionReturn {
     partial_5!(happyMonadReduce, 7, 104, box happyReduction_385)
 }
 
-refute! { fn happyReduction_385<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn95(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCompoundLit, box happy_var_2, reverse(happy_var_5))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_385<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn95(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCompoundLit, box happy_var_2, reverse(happy_var_5))) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20050,8 +20384,10 @@ fn happyReduce_389() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 106, box happyReduction_389)
 }
 
-refute! { fn happyReduction_389<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CUnary, CPreIncOp, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_389<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CUnary, CPreIncOp, box happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20060,8 +20396,10 @@ fn happyReduce_390() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 106, box happyReduction_390)
 }
 
-refute! { fn happyReduction_390<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CUnary, CPreDecOp, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_390<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CUnary, CPreDecOp, box happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20082,8 +20420,10 @@ fn happyReduce_392() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 106, box happyReduction_392)
 }
 
-refute! { fn happyReduction_392<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyAbsSyn107(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CUnary, unL(happy_var_1), box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_392<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyAbsSyn107(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CUnary, unL(happy_var_1), box happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20092,8 +20432,10 @@ fn happyReduce_393() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 106, box happyReduction_393)
 }
 
-refute! { fn happyReduction_393<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CSizeofExpr, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_393<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CSizeofExpr, box happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20102,8 +20444,10 @@ fn happyReduce_394() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 106, box happyReduction_394)
 }
 
-refute! { fn happyReduction_394<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CSizeofType, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_394<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CSizeofType, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20112,8 +20456,10 @@ fn happyReduce_395() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 106, box happyReduction_395)
 }
 
-refute! { fn happyReduction_395<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAlignofExpr, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_395<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAlignofExpr, box happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20122,8 +20468,10 @@ fn happyReduce_396() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 106, box happyReduction_396)
 }
 
-refute! { fn happyReduction_396<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAlignofType, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_396<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CAlignofType, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20132,8 +20480,10 @@ fn happyReduce_397() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 106, box happyReduction_397)
 }
 
-refute! { fn happyReduction_397<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CComplexReal, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_397<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CComplexReal, box happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20142,8 +20492,10 @@ fn happyReduce_398() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 106, box happyReduction_398)
 }
 
-refute! { fn happyReduction_398<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CComplexImag, box happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_398<T>(HappyStk(HappyAbsSyn100(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CComplexImag, box happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20152,8 +20504,10 @@ fn happyReduce_399() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 106, box happyReduction_399)
 }
 
-refute! { fn happyReduction_399<T>(HappyStk(HappyAbsSyn131(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CLabAddrExpr, happy_var_2)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_399<T>(HappyStk(HappyAbsSyn131(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CLabAddrExpr, happy_var_2)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20246,8 +20600,10 @@ fn happyReduce_407() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 108, box happyReduction_407)
 }
 
-refute! { fn happyReduction_407<T>(HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCast, box happy_var_2, box happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_407<T>(HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, partial_1!(CCast, box happy_var_2, box happy_var_4)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20268,8 +20624,10 @@ fn happyReduce_409() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 109, box happyReduction_409)
 }
 
-refute! { fn happyReduction_409<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CMulOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_409<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CMulOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20278,8 +20636,10 @@ fn happyReduce_410() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 109, box happyReduction_410)
 }
 
-refute! { fn happyReduction_410<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CDivOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_410<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CDivOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20288,8 +20648,10 @@ fn happyReduce_411() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 109, box happyReduction_411)
 }
 
-refute! { fn happyReduction_411<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CRmdOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_411<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CRmdOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20310,8 +20672,10 @@ fn happyReduce_413() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 110, box happyReduction_413)
 }
 
-refute! { fn happyReduction_413<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CAddOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_413<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CAddOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20320,8 +20684,10 @@ fn happyReduce_414() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 110, box happyReduction_414)
 }
 
-refute! { fn happyReduction_414<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CSubOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_414<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CSubOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20342,8 +20708,10 @@ fn happyReduce_416() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 111, box happyReduction_416)
 }
 
-refute! { fn happyReduction_416<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CShlOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_416<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CShlOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20352,8 +20720,10 @@ fn happyReduce_417() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 111, box happyReduction_417)
 }
 
-refute! { fn happyReduction_417<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CShrOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_417<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CShrOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20374,8 +20744,10 @@ fn happyReduce_419() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 112, box happyReduction_419)
 }
 
-refute! { fn happyReduction_419<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CLeOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_419<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CLeOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20384,8 +20756,10 @@ fn happyReduce_420() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 112, box happyReduction_420)
 }
 
-refute! { fn happyReduction_420<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CGrOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_420<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CGrOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20394,8 +20768,10 @@ fn happyReduce_421() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 112, box happyReduction_421)
 }
 
-refute! { fn happyReduction_421<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CLeqOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_421<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CLeqOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20404,8 +20780,10 @@ fn happyReduce_422() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 112, box happyReduction_422)
 }
 
-refute! { fn happyReduction_422<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CGeqOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_422<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CGeqOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20426,8 +20804,10 @@ fn happyReduce_424() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 113, box happyReduction_424)
 }
 
-refute! { fn happyReduction_424<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CEqOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_424<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CEqOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20436,8 +20816,10 @@ fn happyReduce_425() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 113, box happyReduction_425)
 }
 
-refute! { fn happyReduction_425<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CNeqOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_425<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CNeqOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20458,8 +20840,10 @@ fn happyReduce_427() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 114, box happyReduction_427)
 }
 
-refute! { fn happyReduction_427<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CAndOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_427<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CAndOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20480,8 +20864,10 @@ fn happyReduce_429() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 115, box happyReduction_429)
 }
 
-refute! { fn happyReduction_429<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CXorOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_429<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CXorOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20502,8 +20888,10 @@ fn happyReduce_431() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 116, box happyReduction_431)
 }
 
-refute! { fn happyReduction_431<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, COrOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_431<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, COrOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20524,8 +20912,10 @@ fn happyReduce_433() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 117, box happyReduction_433)
 }
 
-refute! { fn happyReduction_433<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CLndOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_433<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CLndOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20546,8 +20936,10 @@ fn happyReduce_435() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 118, box happyReduction_435)
 }
 
-refute! { fn happyReduction_435<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CLorOp, box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_435<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CBinary, CLorOp, box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20568,8 +20960,10 @@ fn happyReduce_437() -> ActionReturn {
     partial_5!(happyMonadReduce, 5, 119, box happyReduction_437)
 }
 
-refute! { fn happyReduction_437<T>(HappyStk(HappyAbsSyn100(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCond, box happy_var_1, Some(box happy_var_3), box happy_var_5)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_437<T>(HappyStk(HappyAbsSyn100(happy_var_5), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCond, box happy_var_1, Some(box happy_var_3), box happy_var_5)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20578,8 +20972,10 @@ fn happyReduce_438() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 119, box happyReduction_438)
 }
 
-refute! { fn happyReduction_438<T>(HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCond, box happy_var_1, None, box happy_var_4)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_438<T>(HappyStk(HappyAbsSyn100(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CCond, box happy_var_1, None, box happy_var_4)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20600,8 +20996,10 @@ fn happyReduce_440() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 120, box happyReduction_440)
 }
 
-refute! { fn happyReduction_440<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(HappyAbsSyn121(happy_var_2), Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAssign, unL(happy_var_2), box happy_var_1, box happy_var_3)) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+refute! {
+fn happyReduction_440<T>(HappyStk(HappyAbsSyn100(happy_var_3), Some(box HappyStk(HappyAbsSyn121(happy_var_2), Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), partial_1!(CAssign, unL(happy_var_2), box happy_var_1, box happy_var_3)) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20754,10 +21152,12 @@ fn happyReduce_453() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 122, box happyReduction_453)
 }
 
-refute! { fn happyReduction_453<T>(HappyStk(HappyAbsSyn105(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_453<T>(HappyStk(HappyAbsSyn105(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn100(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             let es = reverse(happy_var_3);
-            withNodeInfo(es.clone(), partial_1!(CComma, __op_concat(happy_var_1, es))) }, (box move |r| { happyReturn(HappyAbsSyn100(r)) }))
+            withNodeInfo(es.clone(), partial_1!(CComma, __op_concat(happy_var_1, es))) },
+              box move |r| happyReturn(HappyAbsSyn100(r)))
 }
 }
 
@@ -20791,9 +21191,7 @@ fn happyReduce_456() -> ActionReturn {
 }
 
 fn happyReduction_456() -> HappyAbsSyn {
-    match () {
-        () => HappyAbsSyn124(None),
-    }
+    HappyAbsSyn124(None)
 }
 
 
@@ -20814,9 +21212,7 @@ fn happyReduce_458() -> ActionReturn {
 }
 
 fn happyReduction_458() -> HappyAbsSyn {
-    match () {
-        () => HappyAbsSyn124(None),
-    }
+    HappyAbsSyn124(None)
 }
 
 
@@ -20848,7 +21244,8 @@ fn happyReduce_461() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 127, box happyReduction_461)
 }
 
-refute! { fn happyReduction_461<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_461<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
                     withNodeInfo(happy_var_1.clone(), box move |_0| {
                         // TODO: I don't get why this is a Fn closure...
@@ -20857,7 +21254,8 @@ refute! { fn happyReduction_461<T>(HappyStk(HappyTerminal(happy_var_1), Some(box
                         } else {
                             panic!("irrefutable pattern")
                         }
-                    }) }, (box move |r| { happyReturn(HappyAbsSyn127(r)) }))
+                    }) },
+              box move |r| happyReturn(HappyAbsSyn127(r)))
 }
 }
 
@@ -20866,7 +21264,8 @@ fn happyReduce_462() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 127, box happyReduction_462)
 }
 
-refute! { fn happyReduction_462<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_462<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
                     withNodeInfo(happy_var_1.clone(), box move |_0| {
                         if let CTokCLit(_, ref c) = happy_var_1 {
@@ -20874,7 +21273,8 @@ refute! { fn happyReduction_462<T>(HappyStk(HappyTerminal(happy_var_1), Some(box
                         } else {
                             panic!("irrefutable pattern")
                         }
-                    }) }, (box move |r| { happyReturn(HappyAbsSyn127(r)) }))
+                    }) },
+              box move |r| happyReturn(HappyAbsSyn127(r)))
 }
 }
 
@@ -20883,7 +21283,8 @@ fn happyReduce_463() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 127, box happyReduction_463)
 }
 
-refute! { fn happyReduction_463<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_463<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
                     withNodeInfo(happy_var_1.clone(), box move |_0| {
                         if let CTokFLit(_, ref f) = happy_var_1 {
@@ -20891,7 +21292,8 @@ refute! { fn happyReduction_463<T>(HappyStk(HappyTerminal(happy_var_1), Some(box
                         } else {
                             panic!("irrefutable pattern")
                         }
-                    }) }, (box move |r| { happyReturn(HappyAbsSyn127(r)) }))
+                    }) },
+              box move |r| happyReturn(HappyAbsSyn127(r)))
 }
 }
 
@@ -20900,7 +21302,8 @@ fn happyReduce_464() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 128, box happyReduction_464)
 }
 
-refute! { fn happyReduction_464<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_464<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             withNodeInfo(happy_var_1.clone(), box move |_0| {
                 if let CTokSLit(_, ref s) = happy_var_1 {
@@ -20908,7 +21311,8 @@ refute! { fn happyReduction_464<T>(HappyStk(HappyTerminal(happy_var_1), Some(box
                 } else {
                     panic!("irrefutable pattern")
                 }
-            }) }, (box move |r| { happyReturn(HappyAbsSyn128(r)) }))
+            }) },
+              box move |r| happyReturn(HappyAbsSyn128(r)))
 }
 }
 
@@ -20917,7 +21321,8 @@ fn happyReduce_465() -> ActionReturn {
     partial_5!(happyMonadReduce, 2, 128, box happyReduction_465)
 }
 
-refute! { fn happyReduction_465<T>(HappyStk(HappyAbsSyn129(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+refute! {
+fn happyReduction_465<T>(HappyStk(HappyAbsSyn129(happy_var_2), Some(box HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             withNodeInfo(happy_var_1.clone(), box move |_0| {
                 if let CTokSLit(_, s) = happy_var_1 {
@@ -20925,7 +21330,8 @@ refute! { fn happyReduction_465<T>(HappyStk(HappyAbsSyn129(happy_var_2), Some(bo
                 } else {
                     panic!("irrefutable pattern")
                 }
-            }) }, (box move |r| { happyReturn(HappyAbsSyn128(r)) }))
+            }) },
+              box move |r| happyReturn(HappyAbsSyn128(r)))
 }
 }
 
@@ -21003,9 +21409,7 @@ fn happyReduce_471() -> ActionReturn {
 }
 
 fn happyReduction_471() -> HappyAbsSyn {
-    match () {
-        () => HappyAbsSyn132(vec![]),
-    }
+    HappyAbsSyn132(vec![])
 }
 
 
@@ -21049,7 +21453,8 @@ fn happyReduce_475() -> ActionReturn {
     partial_5!(happyReduce, 6, 134, box happyReduction_475)
 }
 
-refute! { fn happyReduction_475(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn135(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(_, Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_475(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn135(happy_var_4), Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(_, Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn132(reverse(happy_var_4)), Some(box happyRest))
 }
 }
@@ -21090,9 +21495,7 @@ fn happyReduce_478() -> ActionReturn {
 }
 
 fn happyReduction_478() -> HappyAbsSyn {
-    match () {
-        () => HappyAbsSyn136(None),
-    }
+    HappyAbsSyn136(None)
 }
 
 
@@ -21100,8 +21503,10 @@ fn happyReduce_479() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 136, box happyReduction_479)
 }
 
-refute! { fn happyReduction_479<T>(HappyStk(HappyTerminal(CTokIdent(_, happy_var_1)), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| Some(CAttribute(happy_var_1, vec![], _0))) }, (box move |r| { happyReturn(HappyAbsSyn136(r)) }))
+refute! {
+fn happyReduction_479<T>(HappyStk(HappyTerminal(CTokIdent(_, happy_var_1)), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| Some(CAttribute(happy_var_1, vec![], _0))) },
+              box move |r| happyReturn(HappyAbsSyn136(r)))
 }
 }
 
@@ -21110,8 +21515,10 @@ fn happyReduce_480() -> ActionReturn {
     partial_5!(happyMonadReduce, 1, 136, box happyReduction_480)
 }
 
-refute! { fn happyReduction_480<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1, box move |_0| Some(CAttribute(internalIdent("const".to_string()), vec![], _0))) }, (box move |r| { happyReturn(HappyAbsSyn136(r)) }))
+refute! {
+fn happyReduction_480<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1, box move |_0| Some(CAttribute(internalIdent("const".to_string()), vec![], _0))) },
+              box move |r| happyReturn(HappyAbsSyn136(r)))
 }
 }
 
@@ -21120,8 +21527,10 @@ fn happyReduce_481() -> ActionReturn {
     partial_5!(happyMonadReduce, 4, 136, box happyReduction_481)
 }
 
-refute! { fn happyReduction_481<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn105(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(CTokIdent(_, happy_var_1)), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| Some(CAttribute(happy_var_1, reverse(happy_var_3), _0))) }, (box move |r| { happyReturn(HappyAbsSyn136(r)) }))
+refute! {
+fn happyReduction_481<T>(HappyStk(_, Some(box HappyStk(HappyAbsSyn105(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(CTokIdent(_, happy_var_1)), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| Some(CAttribute(happy_var_1, reverse(happy_var_3), _0))) },
+              box move |r| happyReturn(HappyAbsSyn136(r)))
 }
 }
 
@@ -21130,8 +21539,10 @@ fn happyReduce_482() -> ActionReturn {
     partial_5!(happyMonadReduce, 3, 136, box happyReduction_482)
 }
 
-refute! { fn happyReduction_482<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(CTokIdent(_, happy_var_1)), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| Some(CAttribute(happy_var_1, vec![], _0))) }, (box move |r| { happyReturn(HappyAbsSyn136(r)) }))
+refute! {
+fn happyReduction_482<T>(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyTerminal(CTokIdent(_, happy_var_1)), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
+    happyThen({ withNodeInfo(happy_var_1.clone(), box move |_0| Some(CAttribute(happy_var_1, vec![], _0))) },
+              box move |r| happyReturn(HappyAbsSyn136(r)))
 }
 }
 
@@ -21188,7 +21599,8 @@ fn happyReduce_487() -> ActionReturn {
     partial_5!(happyReduce, 5, 137, box happyReduction_487)
 }
 
-refute! { fn happyReduction_487(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn105(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_487(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn105(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn105(happy_var_1), Some(box happyRest))
 }
 }
@@ -21198,7 +21610,8 @@ fn happyReduce_488() -> ActionReturn {
     partial_5!(happyReduce, 5, 137, box happyReduction_488)
 }
 
-refute! { fn happyReduction_488(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn105(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
+refute! {
+fn happyReduction_488(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn105(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn> {
     HappyStk(HappyAbsSyn105(happy_var_1), Some(box happyRest))
 }
 }
@@ -21735,7 +22148,7 @@ pub fn expressionP() -> P<CExpr> {
 
 
 // Original location: "<command-line>", line 8
-// Original location: "/tmp/ghc25861_0/ghc_2.h", line 1
+// Original location: "/tmp/ghc16004_0/ghc_2.h", line 1
 
 
 
@@ -21960,67 +22373,58 @@ pub fn expressionP() -> P<CExpr> {
 
 // Original location: "<command-line>", line 8
 // Original location: "templates/GenericTemplate.hs", line 1
-
-
-
-
-// Original location: "templates/GenericTemplate.hs", line 16
-
-
-
-
-
-
-
-// Original location: "templates/GenericTemplate.hs", line 36
-
-// Original location: "templates/GenericTemplate.hs", line 46
-
-// Original location: "templates/GenericTemplate.hs", line 55
-
+// -----------------------------------------------------------------------------
+// HappyStk data type
 #[derive(Clone)]
-pub struct HappyStk<a>(a, Option<Box<HappyStk<a>>>);
+struct HappyStk<a>(a, Option<Box<HappyStk<a>>>);
 
 // -----------------------------------------------------------------------------
-/// starting the parse
-fn happyParse(start_state: Action<HappyAbsSyn, HappyStk<HappyAbsSyn>>) -> P<HappyAbsSyn> {
-    // TODO this is lazy failure
-    happyNewToken(start_state, vec![], HappyStk(HappyAbsSyn::HappyErrorToken(0), None))
-}
+// HappyState data type
+struct HappyState<T, F>(Rc<Box<Fn(isize, isize, T, HappyState<T, F>, Vec<HappyState<T, F>>) -> F>>);
 
-// -----------------------------------------------------------------------------
-/// Accepting the parse
-///
-/// If the current token is (1), it means we've just accepted a partial
-/// parse (a %partial parser).  We must ignore the saved token on the top of
-/// the stack in this case.
-fn happyAccept(_0: isize, _1: CToken, _2: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>, _3: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>, _4: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
-    match (_0, _1, _2, _3, _4) {
-        (1, tk, st, sts, HappyStk(_, Some(box HappyStk(ans, _)))) => {
-            happyReturn1(ans)
-        },
-        (j, tk, st, sts, HappyStk(ans, _)) => {
-            (happyReturn1(ans))
-        },
-    }
-}
-
-// -----------------------------------------------------------------------------
-/// HappyState data type (not arrays)
-pub struct HappyState<b, c>(Rc<Box<Fn(isize, isize, b, HappyState<b, c>, Vec<HappyState<b, c>>) -> c>>);
-
-impl<b, c> Clone for HappyState<b, c> {
+impl<T, F> Clone for HappyState<T, F> {
     fn clone(&self) -> Self {
         HappyState(self.0.clone())
     }
 }
 
+// some convenient typedefs
+
+type Stack = HappyStk<HappyAbsSyn>;
+type State<T> = HappyState<Token, Box<FnBox(Stack) -> Monad<T>>>;
+
+type ActionReturn = Box<FnBox(isize, Token, State<HappyAbsSyn>, Vec<State<HappyAbsSyn>>, Stack)
+                        -> Monad<HappyAbsSyn>>;
+
+type Action<A, B> = Box<Fn(isize, isize, Token, HappyState<Token, Box<FnBox(B) -> Monad<A>>>,
+                           Vec<HappyState<Token, Box<FnBox(B) -> Monad<A>>>>, B) -> Monad<A>>;
+
+
 // -----------------------------------------------------------------------------
-/// Shifting a token
-fn happyShift(new_state: Action<HappyAbsSyn, HappyStk<HappyAbsSyn>>, _1: isize, tk: CToken,
-              st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>,
-              sts: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>,
-              stk: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
+// starting the parse
+fn happyParse(start_state: Action<HappyAbsSyn, Stack>) -> Monad<HappyAbsSyn> {
+    // TODO this is lazy failure
+    happyNewToken(start_state, vec![], HappyStk(HappyAbsSyn::HappyErrorToken(0), None))
+}
+
+// -----------------------------------------------------------------------------
+// Accepting the parse
+//
+// If the current token is ERROR_TOK, it means we've just accepted a partial
+// parse (a %partial parser).  We must ignore the saved token on the top of
+// the stack in this case.
+fn happyAccept(j: isize, tk: Token, st: State<HappyAbsSyn>, sts: Vec<State<HappyAbsSyn>>,
+               stk: Stack) -> Monad<HappyAbsSyn> {
+    match (j, stk) {
+        (1, HappyStk(_, Some(box HappyStk(ans, _)))) => happyReturn1(ans),
+        (j, HappyStk(ans, _)) => happyReturn1(ans),
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Shifting a token
+fn happyShift(new_state: Action<HappyAbsSyn, Stack>, _1: isize, tk: Token,
+              st: State<HappyAbsSyn>, sts: Vec<State<HappyAbsSyn>>, stk: Stack) -> Monad<HappyAbsSyn> {
     match _1 {
         1 => {
             let HappyStk(x, _) = stk.clone();
@@ -22043,10 +22447,8 @@ fn happyShift(new_state: Action<HappyAbsSyn, HappyStk<HappyAbsSyn>>, _1: isize, 
 
 // happyReduce is specialised for the common cases.
 
-fn happySpecReduce_0(nt: isize, __fn: HappyAbsSyn, _2: isize, tk: CToken,
-                     st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>,
-                     sts: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>,
-                     stk: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
+fn happySpecReduce_0(nt: isize, __fn: HappyAbsSyn, _2: isize, tk: Token,
+                     st: State<HappyAbsSyn>, sts: Vec<State<HappyAbsSyn>>, stk: Stack) -> Monad<HappyAbsSyn> {
     match _2 {
         1 => happyFail(1, tk, st, sts, stk),
         j => {
@@ -22056,10 +22458,8 @@ fn happySpecReduce_0(nt: isize, __fn: HappyAbsSyn, _2: isize, tk: CToken,
     }
 }
 
-fn happySpecReduce_1(nt: isize, __fn: Box<FnBox(HappyAbsSyn) -> HappyAbsSyn>, _2: isize, tk: CToken,
-                     st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>,
-                     sts: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>,
-                     stk: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
+fn happySpecReduce_1(nt: isize, __fn: Box<FnBox(HappyAbsSyn) -> HappyAbsSyn>, _2: isize, tk: Token,
+                     st: State<HappyAbsSyn>, sts: Vec<State<HappyAbsSyn>>, stk: Stack) -> Monad<HappyAbsSyn> {
     match (_2, stk) {
         (1, stk) => happyFail(1, tk, st, sts, stk),
         (j, HappyStk(v1, stk_q)) => {
@@ -22074,10 +22474,8 @@ fn happySpecReduce_1(nt: isize, __fn: Box<FnBox(HappyAbsSyn) -> HappyAbsSyn>, _2
 }
 
 fn happySpecReduce_2(nt: isize, __fn: Box<FnBox(HappyAbsSyn, HappyAbsSyn) -> HappyAbsSyn>,
-                     _2: isize, tk: CToken,
-                     st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>,
-                     mut sts: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>,
-                     stk: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
+                     _2: isize, tk: Token, st: State<HappyAbsSyn>, mut sts: Vec<State<HappyAbsSyn>>,
+                     stk: Stack) -> Monad<HappyAbsSyn> {
     match (_2, stk) {
         (1, stk) => happyFail(1, tk, st, sts, stk),
         (j, HappyStk(v1, Some(box HappyStk(v2, Some(box stk_q))))) => {
@@ -22094,10 +22492,8 @@ fn happySpecReduce_2(nt: isize, __fn: Box<FnBox(HappyAbsSyn, HappyAbsSyn) -> Hap
 }
 
 fn happySpecReduce_3(nt: isize, __fn: Box<FnBox(HappyAbsSyn, HappyAbsSyn, HappyAbsSyn) -> HappyAbsSyn>,
-                     _2: isize, tk: CToken,
-                     st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>,
-                     mut stses: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>,
-                     stk: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
+                     _2: isize, tk: Token, st: State<HappyAbsSyn>, mut stses: Vec<State<HappyAbsSyn>>,
+                     stk: Stack) -> Monad<HappyAbsSyn> {
     match (_2, stk) {
         (1, stk) => happyFail(1, tk, st, stses, stk),
         (j, HappyStk(v1, Some(box HappyStk(v2, Some(box HappyStk(v3, stk_q)))))) => {
@@ -22117,11 +22513,9 @@ fn happySpecReduce_3(nt: isize, __fn: Box<FnBox(HappyAbsSyn, HappyAbsSyn, HappyA
 }
 
 fn happyReduce<T: 'static>(k: isize, nt: isize,
-                           __fn: Box<FnBox(HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn>>,
-                           _3: isize, tk: CToken,
-                           st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<T>>>,
-                           sts: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<T>>>>,
-                           stk: HappyStk<HappyAbsSyn>) -> P<T> {
+                           __fn: Box<FnBox(Stack) -> Stack>,
+                           _3: isize, tk: Token,
+                           st: State<T>, sts: Vec<State<T>>, stk: Stack) -> Monad<T> {
     match _3 {
         1 => happyFail(1, tk, st, sts, stk),
         j => {
@@ -22135,11 +22529,9 @@ fn happyReduce<T: 'static>(k: isize, nt: isize,
 }
 
 fn happyMonadReduce<T: 'static>(k: isize, nt: isize,
-                                __fn: Box<FnBox(HappyStk<HappyAbsSyn>, CToken) -> P<HappyAbsSyn>>,
-                                _3: isize, tk: CToken,
-                                st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<T>>>,
-                                sts: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<T>>>>,
-                                stk: HappyStk<HappyAbsSyn>) -> P<T> {
+                                __fn: Box<FnBox(Stack, Token) -> Monad<HappyAbsSyn>>,
+                                _3: isize, tk: Token,
+                                st: State<T>, sts: Vec<State<T>>, stk: Stack) -> Monad<T> {
     match _3 {
         1 => happyFail(1, tk, st, sts, stk),
         j => {
@@ -22150,7 +22542,6 @@ fn happyMonadReduce<T: 'static>(k: isize, nt: isize,
             let drop_stk = happyDropStk(k, stk.clone());
 
             happyThen1(__fn(stk.clone(), tk.clone()), box move |r| {
-                clones!(sts1, drop_stk, st1, tk);
                 action(nt, j, tk, st1, sts1)(HappyStk(r, Some(box drop_stk)))
             })
         }
@@ -22158,11 +22549,9 @@ fn happyMonadReduce<T: 'static>(k: isize, nt: isize,
 }
 
 fn happyMonad2Reduce<T: 'static, U>(k: isize, nt: U,
-                                    __fn: Box<FnBox(HappyStk<HappyAbsSyn>, CToken) -> P<HappyAbsSyn>>,
-                                    _3: isize, tk: CToken,
-                                    st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<T>>>,
-                                    sts: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<T>>>>,
-                                    stk: HappyStk<HappyAbsSyn>) -> P<T> {
+                                    __fn: Box<FnBox(Stack, Token) -> Monad<HappyAbsSyn>>,
+                                    _3: isize, tk: Token,
+                                    st: State<T>, sts: Vec<State<T>>, stk: Stack) -> Monad<T> {
     match _3 {
         1 => happyFail(1, tk, st, sts, stk),
         j => {
@@ -22175,7 +22564,6 @@ fn happyMonad2Reduce<T: 'static, U>(k: isize, nt: U,
             let new_state = action;
 
             happyThen1(__fn(stk, tk), box move |r| {
-                clones!(drop_stk, sts1, new_state);
                 happyNewToken(curry_5_1!(new_state), sts1, HappyStk(r, Some(box drop_stk)))
             })
         }
@@ -22198,22 +22586,17 @@ fn happyDropStk<T>(n: isize, stk: HappyStk<T>) -> HappyStk<T> {
 }
 
 // -----------------------------------------------------------------------------
-/// Moving to a new state after a reduction
-fn happyGoto(action: Action<HappyAbsSyn, HappyStk<HappyAbsSyn>>, j: isize, tk: CToken,
-             st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>,
-             _curry_4: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>,
-             _curry_5: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
+// Moving to a new state after a reduction
+fn happyGoto(action: Action<HappyAbsSyn, Stack>, j: isize, tk: Token,
+             st: State<HappyAbsSyn>, sts: Vec<State<HappyAbsSyn>>, stk: Stack) -> Monad<HappyAbsSyn> {
     let action = Rc::new(action);
     let action_ = action.clone();
-    action(j, j, tk, (HappyState(Rc::new(apply_5_1_clone!(action_)))), _curry_4, _curry_5)
+    action(j, j, tk, (HappyState(Rc::new(apply_5_1_clone!(action_)))), sts, stk)
 }
 
 // -----------------------------------------------------------------------------
-/// Error recovery ((1) is the error token)
-fn happyFail<T: 'static>(i: isize, tk: CToken,
-                         old_st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<T>>>,
-                         sts: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<T>>>>,
-                         stk: HappyStk<HappyAbsSyn>) -> P<T> {
+// Error recovery (ERROR_TOK is the error token)
+fn happyFail<T: 'static>(i: isize, tk: Token, old_st: State<T>, sts: Vec<State<T>>, stk: Stack) -> Monad<T> {
     match (i, old_st, stk) {
         (1, old_st, HappyStk(x, Some(_))) => {
             let i = match x {
@@ -22230,18 +22613,6 @@ fn happyFail<T: 'static>(i: isize, tk: CToken,
 
 fn notHappyAtAll<a: 'static>() -> a {
     panic!("Internal Happy error")
-}
-
-fn happySeq<a, b>(a: a, b: b) -> b {
-    seq(a, b)
-}
-
-fn happyDoSeq<a, b>(a: a, b: b) -> b {
-    seq(a, b)
-}
-
-fn happyDontSeq<a, b>(a: a, b: b) -> b {
-    b
 }
 
 // end of Happy Template.

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -21619,14 +21619,11 @@ fn happyReduction_488(HappyStk(_, Some(box HappyStk(_, Some(box HappyStk(_, Some
 
 fn happyNewToken<T: 'static, S: 'static + Clone>(action: Action<T, S>, sts: Vec<HappyState<(CToken), Box<FnBox(S) -> P<T>>>>, stk: S) -> P<T> {
     let action = Rc::new(action);
-    lexC(box move |tk| {
+    lexC(box move |tk: Token| {
         let tk_ = tk.clone();
-        let sts_ = sts.clone();
-        let stk_ = stk.clone();
-        let action_ = action.clone();
         let cont = move |i| {
-            let action__ = action_.clone();
-            action_(i, i, tk_, HappyState(Rc::new(apply_5_1_clone!(action__))), sts_, stk_)
+            let action_ = action.clone();
+            action(i, i, tk_, HappyState(Rc::new(apply_5_1_clone!(action_))), sts, stk)
         };
         match tk {
             CTokEof => cont(247),
@@ -22148,7 +22145,7 @@ pub fn expressionP() -> P<CExpr> {
 
 
 // Original location: "<command-line>", line 8
-// Original location: "/tmp/ghc20480_0/ghc_2.h", line 1
+// Original location: "/tmp/ghc25396_0/ghc_2.h", line 1
 
 
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -15636,7 +15636,7 @@ fn happyReduction_4<T>(HappyStk(HappyAbsSyn8(happy_var_1), Some(box happyRest)):
                           thenP(getNewName(), box |n: Name| {
                               thenP(getCurrentPosition(), box move |p: Position| {
                                   let nodeinfo = NodeInfo::new(p.clone(), (p, 0), n);
-                                  __return(CTranslationUnit(decls, nodeinfo))
+                                  returnP(CTranslationUnit(decls, nodeinfo))
                               })
                           })
                       } else {
@@ -15735,7 +15735,7 @@ fn happyReduce_12() -> ActionReturn {
 
 refute! {
 fn happyReduction_12<T>(HappyStk(HappyAbsSyn12(happy_var_2), Some(box HappyStk(HappyAbsSyn11(happy_var_1), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
+    happyThen({ seqP(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
             CFunctionDef, vec![], happy_var_1, vec![], happy_var_2))) },
               box move |r| happyReturn(HappyAbsSyn10(r)))
 }
@@ -15748,7 +15748,7 @@ fn happyReduce_13() -> ActionReturn {
 
 refute! {
 fn happyReduction_13<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
+    happyThen({ seqP(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
             CFunctionDef, liftCAttrs(happy_var_1), happy_var_2, vec![], happy_var_3))) },
               box move |r| happyReturn(HappyAbsSyn10(r)))
 }
@@ -15761,7 +15761,7 @@ fn happyReduce_14() -> ActionReturn {
 
 refute! {
 fn happyReduction_14<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
+    happyThen({ seqP(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
             CFunctionDef, happy_var_1, happy_var_2, vec![], happy_var_3))) },
               box move |r| happyReturn(HappyAbsSyn10(r)))
 }
@@ -15774,7 +15774,7 @@ fn happyReduce_15() -> ActionReturn {
 
 refute! {
 fn happyReduction_15<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
+    happyThen({ seqP(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
             CFunctionDef, happy_var_1, happy_var_2, vec![], happy_var_3))) },
               box move |r| happyReturn(HappyAbsSyn10(r)))
 }
@@ -15787,7 +15787,7 @@ fn happyReduce_16() -> ActionReturn {
 
 refute! {
 fn happyReduction_16<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
+    happyThen({ seqP(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
             CFunctionDef, reverse(happy_var_1), happy_var_2, vec![], happy_var_3))) },
               box move |r| happyReturn(HappyAbsSyn10(r)))
 }
@@ -15800,7 +15800,7 @@ fn happyReduce_17() -> ActionReturn {
 
 refute! {
 fn happyReduction_17<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
+    happyThen({ seqP(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
             CFunctionDef, liftTypeQuals(happy_var_1), happy_var_2, vec![], happy_var_3))) },
               box move |r| happyReturn(HappyAbsSyn10(r)))
 }
@@ -15813,7 +15813,7 @@ fn happyReduce_18() -> ActionReturn {
 
 refute! {
 fn happyReduction_18<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn11(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
+    happyThen({ seqP(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
             CFunctionDef, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)), happy_var_3, vec![], happy_var_4))) },
               box move |r| happyReturn(HappyAbsSyn10(r)))
 }
@@ -15913,7 +15913,7 @@ refute! {
 fn happyReduction_26<T>(HappyStk(HappyAbsSyn66(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             let declr = reverseDeclr(happy_var_1);
-            rshift_monad(enterScope(), rshift_monad(doFuncParamDeclIdent(declr.clone()), __return(declr))) },
+            seqP(enterScope(), seqP(doFuncParamDeclIdent(declr.clone()), returnP(declr))) },
               box move |r| happyReturn(HappyAbsSyn11(r)))
 }
 }
@@ -16186,7 +16186,7 @@ fn happyReduce_49() -> ActionReturn {
 
 refute! {
 fn happyReduction_49<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
+    happyThen({ seqP(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
             CFunctionDef, happy_var_1, happy_var_2, vec![], happy_var_3))) },
               box move |r| happyReturn(HappyAbsSyn10(r)))
 }
@@ -16199,7 +16199,7 @@ fn happyReduce_50() -> ActionReturn {
 
 refute! {
 fn happyReduction_50<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
+    happyThen({ seqP(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
             CFunctionDef, happy_var_1, happy_var_2, vec![], happy_var_3))) },
               box move |r| happyReturn(HappyAbsSyn10(r)))
 }
@@ -16212,7 +16212,7 @@ fn happyReduce_51() -> ActionReturn {
 
 refute! {
 fn happyReduction_51<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
+    happyThen({ seqP(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
             CFunctionDef, reverse(happy_var_1), happy_var_2, vec![], happy_var_3))) },
               box move |r| happyReturn(HappyAbsSyn10(r)))
 }
@@ -16225,7 +16225,7 @@ fn happyReduce_52() -> ActionReturn {
 
 refute! {
 fn happyReduction_52<T>(HappyStk(HappyAbsSyn12(happy_var_3), Some(box HappyStk(HappyAbsSyn11(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
+    happyThen({ seqP(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
             CFunctionDef, liftTypeQuals(happy_var_1), happy_var_2, vec![], happy_var_3))) },
               box move |r| happyReturn(HappyAbsSyn10(r)))
 }
@@ -16238,7 +16238,7 @@ fn happyReduce_53() -> ActionReturn {
 
 refute! {
 fn happyReduction_53<T>(HappyStk(HappyAbsSyn12(happy_var_4), Some(box HappyStk(HappyAbsSyn11(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ rshift_monad(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
+    happyThen({ seqP(leaveScope(), withNodeInfo(happy_var_1.clone(), partial_1!(
             CFunctionDef, __op_addadd(liftTypeQuals(happy_var_1), liftCAttrs(happy_var_2)), happy_var_3, vec![], happy_var_4))) },
               box move |r| happyReturn(HappyAbsSyn10(r)))
 }
@@ -16710,7 +16710,7 @@ fn happyReduction_92<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(H
     happyThen({
             let declspecs = reverse(happy_var_1.clone());
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
-                rshift_monad(
+                seqP(
                     // TODO: borrow these instead
                     doDeclIdent(declspecs.clone(), declr.clone()),
                     withNodeInfo(happy_var_1, partial_1!(CDecl, declspecs,
@@ -16730,7 +16730,7 @@ fn happyReduction_93<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(H
     happyThen({
             let declspecs = liftTypeQuals(happy_var_1.clone());
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
-                rshift_monad(
+                seqP(
                     doDeclIdent(declspecs.clone(), declr.clone()),
                     withNodeInfo(happy_var_1, partial_1!(CDecl, declspecs,
                                                 vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
@@ -16749,7 +16749,7 @@ fn happyReduction_94<T>(HappyStk(HappyAbsSyn94(happy_var_5), Some(box HappyStk(H
     happyThen({
             let declspecs = liftTypeQuals(happy_var_1.clone());
             thenP(withAsmNameAttrs(happy_var_4, happy_var_3), box move |declr: CDeclrR| {
-                rshift_monad(
+                seqP(
                     doDeclIdent(declspecs.clone(), declr.clone()),
                     withNodeInfo(happy_var_1, partial_1!(CDecl, __op_addadd(declspecs, liftCAttrs(happy_var_2)),
                                                 vec![(Some(reverseDeclr(declr)), happy_var_5, None)])))
@@ -16768,7 +16768,7 @@ fn happyReduction_95<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(H
     happyThen({
             let declspecs = liftCAttrs(happy_var_1.clone());
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
-                rshift_monad(
+                seqP(
                     doDeclIdent(declspecs.clone(), declr.clone()),
                     withNodeInfo(happy_var_1, partial_1!(CDecl, declspecs,
                                                 vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
@@ -16788,7 +16788,7 @@ fn happyReduction_96<T>(HappyStk(HappyAbsSyn94(happy_var_6), Some(box HappyStk(H
             if let CDecl(declspecs, dies, at) = happy_var_1 {
                 let (f, s) = happy_var_5;
                 thenP(withAsmNameAttrs((f, __op_addadd(s, happy_var_3)), happy_var_4), box move |declr: CDeclrR| {
-                    rshift_monad(
+                    seqP(
                         doDeclIdent(declspecs.clone(), declr.clone()),
                         withLength(at, partial_1!(CDecl, declspecs,
                                                   __op_concat((Some(reverseDeclr(declr)), happy_var_6, None), dies))))
@@ -16821,7 +16821,7 @@ refute! {
 fn happyReduction_98<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
-                rshift_monad(
+                seqP(
                     doDeclIdent(happy_var_1.clone(), declr.clone()),
                     withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
             }) },
@@ -16838,7 +16838,7 @@ refute! {
 fn happyReduction_99<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
-                rshift_monad(
+                seqP(
                     doDeclIdent(happy_var_1.clone(), declr.clone()),
                     withNodeInfo(happy_var_1.clone(), partial_1!(CDecl, happy_var_1, vec![(Some(reverseDeclr(declr)), happy_var_4, None)])))
             }) },
@@ -16857,9 +16857,9 @@ fn happyReduction_100<T>(HappyStk(HappyAbsSyn94(happy_var_6), Some(box HappyStk(
             if let CDecl(declspecs, dies, at) = happy_var_1 {
                 let (f, s) = happy_var_5;
                 thenP(withAsmNameAttrs((f, __op_addadd(s, happy_var_3)), happy_var_4), box move |declr: CDeclrR| {
-                    rshift_monad(
+                    seqP(
                         doDeclIdent(declspecs.clone(), declr.clone()),
-                        __return(CDecl(declspecs, __op_concat((Some(reverseDeclr(declr)), happy_var_6, None),
+                        returnP(CDecl(declspecs, __op_concat((Some(reverseDeclr(declr)), happy_var_6, None),
                                                               dies), at)))
                 })
             } else {
@@ -21751,14 +21751,14 @@ fn happyError_<T: 'static>(_: isize, tk: (CToken)) -> P<T> {
 fn happyThen<A: 'static, B: 'static>(m: P<A>, f: Box<FnBox(A) -> P<B>>) -> P<B> {
     thenP(m, f)
 }
-fn happyReturn<A: 'static + Clone>(v: A) -> P<A> {
-    __return(v)
+fn happyReturn<A: 'static>(v: A) -> P<A> {
+    returnP(v)
 }
 fn happyThen1<A: 'static, B: 'static>(m: P<A>, f: Box<FnBox(A) -> P<B>>) -> P<B> {
     thenP(m, f)
 }
-fn happyReturn1<A: 'static + Clone>(v: A) -> P<A> {
-    __return(v)
+fn happyReturn1<A: 'static>(v: A) -> P<A> {
+    returnP(v)
 }
 fn happyError_q<A: 'static>(tk: (CToken)) -> P<A> {
     // TODO
@@ -21818,7 +21818,7 @@ fn withNodeInfo<T: 'static, N: Pos + 'static>(node: N, mkAttrNode: Box<FnBox(Nod
         thenP(getSavedToken(), box move |lastTok| {
             let firstPos = posOf(node);
             let attrs = NodeInfo::new(firstPos, posLenOfTok(lastTok), name);
-            __return(mkAttrNode(attrs))
+            returnP(mkAttrNode(attrs))
         })
     })
 }
@@ -21828,7 +21828,7 @@ fn withLength<a: Clone + 'static>(nodeinfo: NodeInfo, mkAttrNode: Box<FnBox(Node
         let firstPos = nodeinfo.clone().pos();
         let attrs = NodeInfo::new(firstPos, posLenOfTok(lastTok),
                                   nodeinfo.name().unwrap_or_else(|| panic!("nameOfNode")));
-        __return(mkAttrNode(attrs))
+        returnP(mkAttrNode(attrs))
     })
 }
 
@@ -21860,7 +21860,7 @@ fn withAttribute<node: Pos + 'static>(node: node, cattrs: Vec<CAttribute<NodeInf
     thenP(getNewName(), box move |name| {
         let attrs = NodeInfo::with_pos_name(node.posOf(), name);
         let newDeclr = appendDeclrAttrs(cattrs.clone(), mkDeclrNode(attrs));
-        __return(newDeclr)
+        returnP(newDeclr)
     })
 }
 
@@ -21874,7 +21874,7 @@ fn withAttributePF<N: Pos + 'static>(
         let newDeclr: Rc<Box<Fn(CDeclrR) -> CDeclrR>> = Rc::new(box move |_0| {
             appendDeclrAttrs(cattrs.clone(), mkDeclrCtor(attrs.clone(), _0))
         });
-        __return(newDeclr)
+        returnP(newDeclr)
     })
 }
 
@@ -21907,7 +21907,7 @@ fn setAsmName(mAsmName: Option<CStringLiteral<NodeInfo>>,
                   vec!["Duplicate assembler name: ".to_string(), showName(n1), showName(n2)])
         },
         Right(newName) => {
-            __return(CDeclrR(ident, indirections, newName, cattrs, at))
+            returnP(CDeclrR(ident, indirections, newName, cattrs, at))
         },
     }
 }
@@ -22016,7 +22016,7 @@ fn doDeclIdent(declspecs: Vec<CDeclSpec>, CDeclrR(mIdent, _, _, _, _): CDeclrR) 
     };
 
     match mIdent {
-        None => __return(()),
+        None => returnP(()),
         Some(ident) => {
             if any(iypedef, declspecs) { addTypedef(ident) }
             else { shadowTypedef(ident) }
@@ -22044,7 +22044,7 @@ fn doFuncParamDeclIdent(_0: CDeclarator<NodeInfo>) -> P<()> {
             // TODO thread P through this
         },
         _ => {
-            __return(())
+            returnP(())
         },
     }
 }
@@ -22148,7 +22148,7 @@ pub fn expressionP() -> P<CExpr> {
 
 
 // Original location: "<command-line>", line 8
-// Original location: "/tmp/ghc16004_0/ghc_2.h", line 1
+// Original location: "/tmp/ghc20480_0/ghc_2.h", line 1
 
 
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -17,6 +17,7 @@ use data::r_list::Reversed;
 use data::node::*;
 use data::r_list::snoc;
 use data::ident::*;
+use data::name::*;
 use syntax::ops::*;
 use parser::lexer::{lexC, parseError};
 use parser::builtin::builtinTypeNames;
@@ -192,11 +193,11 @@ enum HappyAbsSyn {
 use self::HappyAbsSyn::*;
 
 
-type ActionReturn = Box<Fn(isize, (CToken), HappyState<(CToken), Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>,
-                           Vec<HappyState<(CToken), Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>,
+type ActionReturn = Box<FnBox(isize, (CToken), HappyState<(CToken), Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>,
+                           Vec<HappyState<(CToken), Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>,
                            HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>;
-type Action<A, B> = Box<Fn(isize, isize, (CToken), HappyState<(CToken), Box<Fn(B) -> P<A>>>,
-                           Vec<HappyState<(CToken), Box<Fn(B) -> P<A>>>>, B) -> P<A>>;
+type Action<A, B> = Box<Fn(isize, isize, (CToken), HappyState<(CToken), Box<FnBox(B) -> P<A>>>,
+                           Vec<HappyState<(CToken), Box<FnBox(B) -> P<A>>>>, B) -> P<A>>;
 
 fn action_0(i: isize) -> ActionReturn {
     match i {
@@ -15708,9 +15709,9 @@ refute! { fn happyReduction_4<T>(HappyStk(HappyAbsSyn8(happy_var_1), Some(box ha
     happyThen({
                       let decls = reverse(happy_var_1);
                       if decls.len() == 0 {
-                          thenP(getNewName(), box move |n| {
+                          thenP(getNewName(), box move |n: Name| {
                               let decls = decls.clone();
-                              thenP(getCurrentPosition(), box move |p| {
+                              thenP(getCurrentPosition(), box move |p: Position| {
                                   let decls = decls.clone();
                                   __return(CTranslationUnit::<NodeInfo>(
                                       decls.clone(),
@@ -16697,7 +16698,7 @@ fn happyReduce_92() -> ActionReturn {
 refute! { fn happyReduction_92<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn38(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             let declspecs = reverse(happy_var_1.clone());
-            thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr| {
+            thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
                 clones!(happy_var_4, happy_var_1, declspecs);
                 // TODO: the return value here should not be ignored!
                 doDeclIdent(declspecs.clone(), declr.clone());
@@ -16715,7 +16716,7 @@ fn happyReduce_93() -> ActionReturn {
 refute! { fn happyReduction_93<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             let declspecs = liftTypeQuals(happy_var_1.clone());
-            thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr| {
+            thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
                 clones!(happy_var_4, happy_var_1, declspecs);
                 // TODO: the return value here should not be ignored!
                 doDeclIdent(declspecs.clone(), declr.clone());
@@ -16733,7 +16734,7 @@ fn happyReduce_94() -> ActionReturn {
 refute! { fn happyReduction_94<T>(HappyStk(HappyAbsSyn94(happy_var_5), Some(box HappyStk(HappyAbsSyn35(happy_var_4), Some(box HappyStk(HappyAbsSyn66(happy_var_3), Some(box HappyStk(HappyAbsSyn132(happy_var_2), Some(box HappyStk(HappyAbsSyn65(happy_var_1), Some(box happyRest)))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             let declspecs = liftTypeQuals(happy_var_1.clone());
-            thenP(withAsmNameAttrs(happy_var_4, happy_var_3), box move |declr| {
+            thenP(withAsmNameAttrs(happy_var_4, happy_var_3), box move |declr: CDeclrR| {
                 clones!(happy_var_2, happy_var_5, declspecs);
                 // TODO: the return value here should not be ignored!
                 doDeclIdent(declspecs.clone(), declr.clone());
@@ -16751,7 +16752,7 @@ fn happyReduce_95() -> ActionReturn {
 refute! { fn happyReduction_95<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn132(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             let declspecs = liftCAttrs(happy_var_1.clone());
-            thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr| {
+            thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
                 clones!(happy_var_4, declspecs);
                 // TODO: the return value here should not be ignored!
                 doDeclIdent(declspecs.clone(), declr.clone());
@@ -16770,7 +16771,7 @@ refute! { fn happyReduction_96<T>(HappyStk(HappyAbsSyn94(happy_var_6), Some(box 
     happyThen({
             if let CDecl(declspecs, dies, at) = happy_var_1 {
                 clones!(happy_var_5);
-                thenP(withAsmNameAttrs((fst(happy_var_5.clone()), __op_addadd(snd(happy_var_5), happy_var_3)), happy_var_4), box move |declr| {
+                thenP(withAsmNameAttrs((fst(happy_var_5.clone()), __op_addadd(snd(happy_var_5), happy_var_3)), happy_var_4), box move |declr: CDeclrR| {
                     clones!(happy_var_6, declspecs, dies, at);
                     // TODO: the return value here should not be ignored!
                     doDeclIdent(declspecs.clone(), declr.clone());
@@ -16803,7 +16804,7 @@ fn happyReduce_98() -> ActionReturn {
 
 refute! { fn happyReduction_98<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
-            thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr| {
+            thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
                 clones!(happy_var_1, happy_var_4);
                 // TODO: the return value here should not be ignored!
                 doDeclIdent(happy_var_1.clone(), declr.clone());
@@ -16819,7 +16820,7 @@ fn happyReduce_99() -> ActionReturn {
 
 refute! { fn happyReduction_99<T>(HappyStk(HappyAbsSyn94(happy_var_4), Some(box HappyStk(HappyAbsSyn35(happy_var_3), Some(box HappyStk(HappyAbsSyn66(happy_var_2), Some(box HappyStk(HappyAbsSyn37(happy_var_1), Some(box happyRest)))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
-            thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr| {
+            thenP(withAsmNameAttrs(happy_var_3, happy_var_2), box move |declr: CDeclrR| {
                 clones!(happy_var_1, happy_var_4);
                 // TODO: the return value here should not be ignored!
                 doDeclIdent(happy_var_1.clone(), declr.clone());
@@ -16836,7 +16837,7 @@ fn happyReduce_100() -> ActionReturn {
 refute! { fn happyReduction_100<T>(HappyStk(HappyAbsSyn94(happy_var_6), Some(box HappyStk(HappyAbsSyn35(happy_var_5), Some(box HappyStk(HappyAbsSyn66(happy_var_4), Some(box HappyStk(HappyAbsSyn132(happy_var_3), Some(box HappyStk(_, Some(box HappyStk(HappyAbsSyn32(happy_var_1), Some(box happyRest)))))))))))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             if let CDecl(declspecs, dies, at) = happy_var_1 {
-                thenP(withAsmNameAttrs((fst(happy_var_5.clone()), __op_addadd(snd(happy_var_5), happy_var_3)), happy_var_4), box move |declr| {
+                thenP(withAsmNameAttrs((fst(happy_var_5.clone()), __op_addadd(snd(happy_var_5), happy_var_3)), happy_var_4), box move |declr: CDeclrR| {
                     // TODO: the return value here should not be ignored!
                     doDeclIdent(declspecs.clone(), declr.clone());
                     __return(CDecl(declspecs.clone(), __op_concat((Some(reverseDeclr(declr)),
@@ -21232,21 +21233,19 @@ refute! { fn happyReduction_488(HappyStk(_, Some(box HappyStk(_, Some(box HappyS
 }
 
 
-fn happyNewToken<T: 'static, S: 'static + Clone>(action: Action<T, S>, sts: Vec<HappyState<(CToken), Box<Fn(S) -> P<T>>>>, stk: S) -> P<T> {
+fn happyNewToken<T: 'static, S: 'static + Clone>(action: Action<T, S>, sts: Vec<HappyState<(CToken), Box<FnBox(S) -> P<T>>>>, stk: S) -> P<T> {
     let action = Rc::new(action);
     lexC(box move |tk| {
         let tk_ = tk.clone();
-        let stk_ = stk.clone();
         let sts_ = sts.clone();
+        let stk_ = stk.clone();
         let action_ = action.clone();
-        let cont = box move |i| {
-            (action_.clone())(i, i, tk_.clone(), HappyState(Rc::new(apply_5_1_clone!(action_.clone()))), sts_.clone(), stk_.clone())
+        let cont = move |i| {
+            let action__ = action_.clone();
+            action_(i, i, tk_, HappyState(Rc::new(apply_5_1_clone!(action__))), sts_, stk_)
         };
         match tk {
-            CTokEof => {
-                let action_ = action.clone();
-                action(247, 247, tk, HappyState(Rc::new(apply_5_1_clone!(action_))), sts.clone(), stk.clone())
-            },
+            CTokEof => cont(247),
             CTokLParen(_) => cont(138),
             CTokRParen(_) => cont(139),
             CTokLBracket(_) => cont(140),
@@ -21365,13 +21364,13 @@ fn happyError_<T: 'static>(_: isize, tk: (CToken)) -> P<T> {
 }
 
 
-fn happyThen<A: 'static, B: 'static>(m: P<A>, f: Box<Fn(A) -> P<B>>) -> P<B> {
+fn happyThen<A: 'static, B: 'static>(m: P<A>, f: Box<FnBox(A) -> P<B>>) -> P<B> {
     thenP(m, f)
 }
 fn happyReturn<A: 'static + Clone>(v: A) -> P<A> {
     __return(v)
 }
-fn happyThen1<A: 'static, B: 'static>(m: P<A>, f: Box<Fn(A) -> P<B>>) -> P<B> {
+fn happyThen1<A: 'static, B: 'static>(m: P<A>, f: Box<FnBox(A) -> P<B>>) -> P<B> {
     thenP(m, f)
 }
 fn happyReturn1<A: 'static + Clone>(v: A) -> P<A> {
@@ -21435,12 +21434,12 @@ fn withNodeInfo<a: Clone + 'static, node: Pos + Clone + 'static>(
     node: node, mkAttrNode: Box<Fn(NodeInfo) -> a>) -> P<a>
 {
     let mkAttrNode = Rc::new(mkAttrNode);
-    thenP(getNewName(), box move |name| {
+    thenP(getNewName(), box move |name: Name| {
         let node = node.clone();
         let mkAttrNode = mkAttrNode.clone();
         thenP(getSavedToken(), box move |lastTok| {
             let firstPos = posOf(node.clone());
-            let attrs = NodeInfo::new(firstPos, posLenOfTok(lastTok), name.clone());
+            let attrs = NodeInfo::new(firstPos, posLenOfTok(lastTok), name);
             __return(mkAttrNode(attrs))
         })
     })
@@ -21786,7 +21785,7 @@ pub fn expressionP() -> P<CExpr> {
 
 
 // Original location: "<command-line>", line 8
-// Original location: "/tmp/ghc31580_0/ghc_2.h", line 1
+// Original location: "/tmp/ghc25861_0/ghc_2.h", line 1
 
 
 
@@ -22034,7 +22033,7 @@ pub struct HappyStk<a>(a, Option<Box<HappyStk<a>>>);
 
 // -----------------------------------------------------------------------------
 /// starting the parse
-fn happyParse(start_state: Box<Fn(isize, isize, CToken, HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>, Vec<HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>, HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>) -> P<HappyAbsSyn> {
+fn happyParse(start_state: Action<HappyAbsSyn, HappyStk<HappyAbsSyn>>) -> P<HappyAbsSyn> {
     // TODO this is lazy failure
     happyNewToken(start_state, vec![], HappyStk(HappyAbsSyn::HappyErrorToken(0), None))
 }
@@ -22045,7 +22044,7 @@ fn happyParse(start_state: Box<Fn(isize, isize, CToken, HappyState<CToken, Box<F
 /// If the current token is (1), it means we've just accepted a partial
 /// parse (a %partial parser).  We must ignore the saved token on the top of
 /// the stack in this case.
-fn happyAccept(_0: isize, _1: CToken, _2: HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>, _3: Vec<HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>, _4: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
+fn happyAccept(_0: isize, _1: CToken, _2: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>, _3: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>, _4: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
     match (_0, _1, _2, _3, _4) {
         (1, tk, st, sts, HappyStk(_, Some(box HappyStk(ans, _)))) => {
             happyReturn1(ans)
@@ -22068,202 +22067,192 @@ impl<b, c> Clone for HappyState<b, c> {
 
 // -----------------------------------------------------------------------------
 /// Shifting a token
-fn happyShift(_0: Box<Fn(isize, isize, CToken, HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>, Vec<HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>, HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>, _1: isize, _2: CToken, _3: HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>, _4: Vec<HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>, _5: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
-    match (_0, _1, _2, _3, _4, _5) {
-        (new_state, 1, tk, st, sts, stk) => {
-            {
-                let HappyStk(x, _) = stk.clone();
-                let i = (match x {
-                        HappyErrorToken(i) => {
-                            i
-                        },
-                        _ => unreachable!(),
-                    });
+fn happyShift(new_state: Action<HappyAbsSyn, HappyStk<HappyAbsSyn>>, _1: isize, tk: CToken,
+              st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>,
+              sts: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>,
+              stk: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
+    match _1 {
+        1 => {
+            let HappyStk(x, _) = stk.clone();
+            let i = (match x {
+                HappyErrorToken(i) => {
+                    i
+                },
+                _ => unreachable!(),
+            });
 
             let new_state = Rc::new(new_state);
             let new_state_ = new_state.clone();
-            new_state(i, i, tk, (HappyState(Rc::new(apply_5_1_clone!(new_state_)))), (__op_concat(st, sts)), stk)            }
-        },
-        (new_state, i, tk, st, sts, stk) => {
-            happyNewToken(new_state, (__op_concat(st, sts)), (HappyStk((HappyTerminal(tk)), Some(box stk))))
+            new_state(i, i, tk, (HappyState(Rc::new(apply_5_1_clone!(new_state_)))), __op_concat(st, sts), stk)
+        }
+        i => {
+            happyNewToken(new_state, __op_concat(st, sts), (HappyStk(HappyTerminal(tk), Some(box stk))))
         },
     }
 }
 
 // happyReduce is specialised for the common cases.
 
-fn happySpecReduce_0(_0: isize, _1: HappyAbsSyn, _2: isize, _3: CToken, _4: HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>, _5: Vec<HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>, _6: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
-    match (_0, _1, _2, _3, _4, _5, _6) {
-        (i, __fn, 1, tk, st, sts, stk) => {
-            happyFail( (1), tk, st, sts, stk)
-        },
-        (nt, __fn, j, tk, st, sts, stk) => {
+fn happySpecReduce_0(nt: isize, __fn: HappyAbsSyn, _2: isize, tk: CToken,
+                     st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>,
+                     sts: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>,
+                     stk: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
+    match _2 {
+        1 => happyFail(1, tk, st, sts, stk),
+        j => {
             let HappyState(action) = st.clone();
-            action(nt, j, tk, st.clone(), (__op_concat(st, sts)))((HappyStk(__fn, Some(box stk))))
+            action(nt, j, tk, st.clone(), __op_concat(st, sts))(HappyStk(__fn, Some(box stk)))
         },
     }
 }
 
-fn happySpecReduce_1(_0: isize, _1: Box<Fn(HappyAbsSyn) -> HappyAbsSyn>, _2: isize, _3: CToken, _4: HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>, _5: Vec<HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>, _6: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
-    match (_0, _1, _2, _3, _4, _5, _6) {
-        (i, __fn, 1, tk, st, sts, stk) => {
-            happyFail((1), tk, st, sts, stk)
-        },
-        (nt, __fn, j, tk, _, sts, HappyStk(v1, stk_q)) => {
-            {
-                // TODO assert len > 0?
-                let st = sts.clone().remove(0);
-                let HappyState(action) = st.clone();
-                let r = __fn(v1);
+fn happySpecReduce_1(nt: isize, __fn: Box<FnBox(HappyAbsSyn) -> HappyAbsSyn>, _2: isize, tk: CToken,
+                     st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>,
+                     sts: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>,
+                     stk: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
+    match (_2, stk) {
+        (1, stk) => happyFail(1, tk, st, sts, stk),
+        (j, HappyStk(v1, stk_q)) => {
+            // TODO assert len > 0?
+            let st = sts.clone().remove(0);
+            let HappyState(action) = st.clone();
+            let r = __fn(v1);
 
-            happySeq(r.clone(), (action(nt, j, tk, st, sts)((HappyStk(r, stk_q)))))            }
-        },
-    }
-}
-
-fn happySpecReduce_2(_0: isize, _1: Box<Fn(HappyAbsSyn, HappyAbsSyn) -> HappyAbsSyn>, _2: isize, _3: CToken, _4: HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>, _5: Vec<HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>, _6: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
-    match (_0, _1, _2, _3, _4, _5, _6) {
-        (i, __fn, 1, tk, st, sts, stk) => {
-            happyFail( (1), tk, st, sts, stk)
-        },
-        (nt, __fn, j, tk, _, mut sts, HappyStk(v1, Some(box HappyStk(v2, Some(box stk_q))))) => {
-            {
-                sts.remove(0);
-                let st = sts.clone().remove(0);
-                let HappyState(action) = st.clone();
-
-                let r = __fn(v1, v2);
-
-            happySeq(r.clone(), (action(nt, j, tk, st, sts)((HappyStk(r, Some(box stk_q))))))            }
-        },
-        _ => {
-            panic!("IRREFUTABLE PATTERN")
+            action(nt, j, tk, st, sts)(HappyStk(r, stk_q))
         }
     }
 }
 
-fn happySpecReduce_3(_0: isize, _1: Box<Fn(HappyAbsSyn, HappyAbsSyn, HappyAbsSyn) -> HappyAbsSyn>, _2: isize, _3: CToken, _4: HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>, _5: Vec<HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>, _6: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
-    match (_0, _1, _2, _3, _4, _5, _6) {
-        (i, __fn, 1, tk, st, sts, stk) => {
-            happyFail( (1), tk, st, sts, stk)
-        },
-        (nt, __fn, j, tk, _, mut stses, HappyStk(v1, Some(box HappyStk(v2, Some(box HappyStk(v3, stk_q)))))) => {
-            {
-                stses.remove(0);
-                stses.remove(0);
-                let sts = stses.clone();
-                let st = stses.clone().remove(0);
-                let HappyState(action) = st.clone();
-
-                let r = __fn(v1, v2, v3);
-
-            happySeq(r.clone(), (action(nt, j, tk, st, sts)(HappyStk(r, stk_q))))            }
+fn happySpecReduce_2(nt: isize, __fn: Box<FnBox(HappyAbsSyn, HappyAbsSyn) -> HappyAbsSyn>,
+                     _2: isize, tk: CToken,
+                     st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>,
+                     mut sts: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>,
+                     stk: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
+    match (_2, stk) {
+        (1, stk) => happyFail(1, tk, st, sts, stk),
+        (j, HappyStk(v1, Some(box HappyStk(v2, Some(box stk_q))))) => {
+            sts.remove(0);
+            let st = sts.clone().remove(0);
+            let HappyState(action) = st.clone();
+            let r = __fn(v1, v2);
+            action(nt, j, tk, st, sts)(HappyStk(r, Some(box stk_q)))
         },
         _ => {
-            panic!("IRREFUTABLE PATTERN");
+            panic!("irrefutable pattern")
         }
     }
 }
 
-fn happyReduce<a00: 'static>(_0: isize, _1: isize, _2: Box<Fn(HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn>>, _3: isize, _4: CToken, _5: HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<a00>>>, _6: Vec<HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<a00>>>>, _7: HappyStk<HappyAbsSyn>) -> P<a00> {
-    match (_0, _1, _2, _3, _4, _5, _6, _7) {
-        (k, i, __fn, 1, tk, st, sts, stk) => {
-            happyFail( (1), tk, st, sts, stk)
-        },
-        (k, nt, __fn, j, tk, st, sts, stk) => {
-            match happyDrop(((k - ((1)))), sts) {
-                sts1 => {
-                    {
-                        let st1 = sts1.clone().remove(0);
-                        let HappyState(action) = st1.clone();
+fn happySpecReduce_3(nt: isize, __fn: Box<FnBox(HappyAbsSyn, HappyAbsSyn, HappyAbsSyn) -> HappyAbsSyn>,
+                     _2: isize, tk: CToken,
+                     st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>,
+                     mut stses: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>,
+                     stk: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
+    match (_2, stk) {
+        (1, stk) => happyFail(1, tk, st, stses, stk),
+        (j, HappyStk(v1, Some(box HappyStk(v2, Some(box HappyStk(v3, stk_q)))))) => {
+            stses.remove(0);
+            stses.remove(0);
+            let sts = stses.clone();
+            let st = stses.clone().remove(0);
+            let HappyState(action) = st.clone();
 
-                        // it doesn't hurt to always seq here...
-                        let r = __fn(stk);
-
-                    happyDoSeq(r.clone(), (action(nt, j, tk, st1, sts1)(r)))                    }
-                },
-            }
-        },
-    }
-}
-
-fn happyMonadReduce<b00: 'static>(_0: isize, _1: isize, _2: Box<Fn(HappyStk<HappyAbsSyn>, CToken) -> P<HappyAbsSyn>>, _3: isize, _4: CToken, _5: HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<b00>>>, _6: Vec<HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<b00>>>>, _7: HappyStk<HappyAbsSyn>) -> P<b00> {
-    match (_0, _1, _2, _3, _4, _5, _6, _7) {
-        (k, nt, __fn, 1, tk, st, sts, stk) => {
-            happyFail((1), tk, st, sts, stk)
-        },
-        (k, nt, __fn, j, tk, st, sts, stk) => {
-            match happyDrop(k, (__op_concat(st, sts))) {
-                sts1 => {
-                    {
-                        let st1 = sts1.clone().remove(0);
-                        let HappyState(action) = st1.clone();
-
-                        let drop_stk = happyDropStk(k, stk.clone());
-
-                    happyThen1((__fn(stk.clone(), tk.clone())), (box move |r| { clones!(sts1, drop_stk, st1, tk);
-                        action(nt, j, tk, st1, sts1)((HappyStk(r, Some(box drop_stk)))) }))                    }
-                },
-            }
-        },
-    }
-}
-
-fn happyMonad2Reduce<b00: 'static, t0>(_0: isize, _1: t0, _2: Box<Fn(HappyStk<HappyAbsSyn>, CToken) -> P<HappyAbsSyn>>, _3: isize, _4: CToken, _5: HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<b00>>>, _6: Vec<HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<b00>>>>, _7: HappyStk<HappyAbsSyn>) -> P<b00> {
-    match (_0, _1, _2, _3, _4, _5, _6, _7) {
-        (k, nt, __fn, 1, tk, st, sts, stk) => {
-            happyFail( (1), tk, st, sts, stk)
-        },
-        (k, nt, __fn, j, tk, st, sts, stk) => {
-            match happyDrop(k, (__op_concat(st, sts))) {
-                sts1 => { {
-                        let st1 = sts1.clone().remove(0);
-                        let HappyState(action) = st1.clone();
-
-                        let drop_stk = happyDropStk(k, stk.clone());
-
-                        let new_state = action;
-
-                    happyThen1(__fn(stk, tk),
-                        box move |r| { clones!(drop_stk, sts1, new_state);
-                            happyNewToken(curry_5_1!(new_state), sts1, (HappyStk(r, Some(box drop_stk))))
-                        }
-                    ) }
-                },
-            }
-        },
-    }
-}
-
-fn happyDrop<t0>(_0: isize, _1: Vec<t0>) -> Vec<t0> {
-    match (_0, _1) {
-        (0, l) => {
-            l
-        },
-        (n, mut t) => {
-            t.remove(0); // TODO this can panic, how does Haskell do this
-            happyDrop(((n - ((1)))), t)
-        },
-    }
-}
-
-fn happyDropStk<t0>(_0: isize, _1: HappyStk<t0>) -> HappyStk<t0> {
-    match (_0, _1) {
-        (0, l) => {
-            l
-        },
-        (n, HappyStk(x, Some(box xs))) => {
-            happyDropStk(((n - ((1)))), xs)
+            let r = __fn(v1, v2, v3);
+            action(nt, j, tk, st, sts)(HappyStk(r, stk_q))
         },
         _ => {
-            panic!("REFUTABLE PATTERN");
+            panic!("irrefutable pattern")
         }
+    }
+}
+
+fn happyReduce<T: 'static>(k: isize, nt: isize,
+                           __fn: Box<FnBox(HappyStk<HappyAbsSyn>) -> HappyStk<HappyAbsSyn>>,
+                           _3: isize, tk: CToken,
+                           st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<T>>>,
+                           sts: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<T>>>>,
+                           stk: HappyStk<HappyAbsSyn>) -> P<T> {
+    match _3 {
+        1 => happyFail(1, tk, st, sts, stk),
+        j => {
+            let sts1 = happyDrop(k - 1, sts);
+            let st1 = sts1.clone().remove(0);
+            let HappyState(action) = st1.clone();
+            let r = __fn(stk);
+            action(nt, j, tk, st1, sts1)(r)
+        },
+    }
+}
+
+fn happyMonadReduce<T: 'static>(k: isize, nt: isize,
+                                __fn: Box<FnBox(HappyStk<HappyAbsSyn>, CToken) -> P<HappyAbsSyn>>,
+                                _3: isize, tk: CToken,
+                                st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<T>>>,
+                                sts: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<T>>>>,
+                                stk: HappyStk<HappyAbsSyn>) -> P<T> {
+    match _3 {
+        1 => happyFail(1, tk, st, sts, stk),
+        j => {
+            let sts1 = happyDrop(k, __op_concat(st, sts));
+            let st1 = sts1.clone().remove(0);
+            let HappyState(action) = st1.clone();
+
+            let drop_stk = happyDropStk(k, stk.clone());
+
+            happyThen1(__fn(stk.clone(), tk.clone()), box move |r| {
+                clones!(sts1, drop_stk, st1, tk);
+                action(nt, j, tk, st1, sts1)(HappyStk(r, Some(box drop_stk)))
+            })
+        }
+    }
+}
+
+fn happyMonad2Reduce<T: 'static, U>(k: isize, nt: U,
+                                    __fn: Box<FnBox(HappyStk<HappyAbsSyn>, CToken) -> P<HappyAbsSyn>>,
+                                    _3: isize, tk: CToken,
+                                    st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<T>>>,
+                                    sts: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<T>>>>,
+                                    stk: HappyStk<HappyAbsSyn>) -> P<T> {
+    match _3 {
+        1 => happyFail(1, tk, st, sts, stk),
+        j => {
+            let sts1 = happyDrop(k, __op_concat(st, sts));
+            let st1 = sts1.clone().remove(0);
+            let HappyState(action) = st1.clone();
+
+            let drop_stk = happyDropStk(k, stk.clone());
+
+            let new_state = action;
+
+            happyThen1(__fn(stk, tk), box move |r| {
+                clones!(drop_stk, sts1, new_state);
+                happyNewToken(curry_5_1!(new_state), sts1, HappyStk(r, Some(box drop_stk)))
+            })
+        }
+    }
+}
+
+fn happyDrop<T>(n: isize, mut l: Vec<T>) -> Vec<T> {
+    if n == 0 { l } else {
+        l.remove(0);
+        happyDrop(n - 1, l)
+    }
+}
+
+fn happyDropStk<T>(n: isize, stk: HappyStk<T>) -> HappyStk<T> {
+    match (n, stk) {
+        (0, stk) => stk,
+        (n, HappyStk(x, Some(box xs))) => happyDropStk(n - 1, xs),
+        _ => panic!("irrefutable pattern"),
     }
 }
 
 // -----------------------------------------------------------------------------
 /// Moving to a new state after a reduction
-fn happyGoto(action: Box<Fn(isize, isize, CToken, HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>, Vec<HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>, HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>, j: isize, tk: CToken, st: HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>, _curry_4: Vec<HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>, _curry_5: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
+fn happyGoto(action: Action<HappyAbsSyn, HappyStk<HappyAbsSyn>>, j: isize, tk: CToken,
+             st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>,
+             _curry_4: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn>>>>,
+             _curry_5: HappyStk<HappyAbsSyn>) -> P<HappyAbsSyn> {
     let action = Rc::new(action);
     let action_ = action.clone();
     action(j, j, tk, (HappyState(Rc::new(apply_5_1_clone!(action_)))), _curry_4, _curry_5)
@@ -22271,21 +22260,20 @@ fn happyGoto(action: Box<Fn(isize, isize, CToken, HappyState<CToken, Box<Fn(Happ
 
 // -----------------------------------------------------------------------------
 /// Error recovery ((1) is the error token)
-fn happyFail<a0: 'static>(_0: isize, _1: CToken, _2: HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<a0>>>, _3: Vec<HappyState<CToken, Box<Fn(HappyStk<HappyAbsSyn>) -> P<a0>>>>, _4: HappyStk<HappyAbsSyn>) -> P<a0> {
-    match (_0, _1, _2, _3, _4) {
-        (1, tk, old_st, _, HappyStk(x, Some(_))) => {
-            {
-                let i = (match x {
-                        HappyErrorToken(i) => {
-                            i
-                        },
-                        _ => unreachable!(),
-                    });
-
-            happyError_(i, tk)            }
+fn happyFail<T: 'static>(i: isize, tk: CToken,
+                         old_st: HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<T>>>,
+                         sts: Vec<HappyState<CToken, Box<FnBox(HappyStk<HappyAbsSyn>) -> P<T>>>>,
+                         stk: HappyStk<HappyAbsSyn>) -> P<T> {
+    match (i, old_st, stk) {
+        (1, old_st, HappyStk(x, Some(_))) => {
+            let i = match x {
+                HappyErrorToken(i) => i,
+                _ => unreachable!(),
+            };
+            happyError_(i, tk)
         },
-        (i, tk, HappyState(action), sts, stk) => {
-            action((1), (1), tk, (HappyState(action.clone())), sts)((HappyStk((HappyErrorToken(i)), Some(box stk))))
+        (i, HappyState(action), stk) => {
+            action(1, 1, tk, HappyState(action.clone()), sts)(HappyStk(HappyErrorToken(i), Some(box stk)))
         },
     }
 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -17935,7 +17935,7 @@ fn happyReduce_189() -> ActionReturn {
 
 fn happyReduction_189(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn54(Located(CStructTag, posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn54(Located(CStructTag, happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -17947,7 +17947,7 @@ fn happyReduce_190() -> ActionReturn {
 
 fn happyReduction_190(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn54(Located(CUnionTag, posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn54(Located(CUnionTag, happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -20518,7 +20518,7 @@ fn happyReduce_400() -> ActionReturn {
 
 fn happyReduction_400(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn107(Located(CAdrOp,  posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn107(Located(CAdrOp,  happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -20530,7 +20530,7 @@ fn happyReduce_401() -> ActionReturn {
 
 fn happyReduction_401(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn107(Located(CIndOp,  posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn107(Located(CIndOp,  happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -20542,7 +20542,7 @@ fn happyReduce_402() -> ActionReturn {
 
 fn happyReduction_402(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn107(Located(CPlusOp, posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn107(Located(CPlusOp, happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -20554,7 +20554,7 @@ fn happyReduce_403() -> ActionReturn {
 
 fn happyReduction_403(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn107(Located(CMinOp,  posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn107(Located(CMinOp,  happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -20566,7 +20566,7 @@ fn happyReduce_404() -> ActionReturn {
 
 fn happyReduction_404(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn107(Located(CCompOp, posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn107(Located(CCompOp, happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -20578,7 +20578,7 @@ fn happyReduce_405() -> ActionReturn {
 
 fn happyReduction_405(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn107(Located(CNegOp,  posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn107(Located(CNegOp,  happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -21010,7 +21010,7 @@ fn happyReduce_441() -> ActionReturn {
 
 fn happyReduction_441(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CAssignOp, posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CAssignOp, happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -21022,7 +21022,7 @@ fn happyReduce_442() -> ActionReturn {
 
 fn happyReduction_442(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CMulAssOp, posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CMulAssOp, happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -21034,7 +21034,7 @@ fn happyReduce_443() -> ActionReturn {
 
 fn happyReduction_443(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CDivAssOp, posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CDivAssOp, happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -21046,7 +21046,7 @@ fn happyReduce_444() -> ActionReturn {
 
 fn happyReduction_444(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CRmdAssOp, posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CRmdAssOp, happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -21058,7 +21058,7 @@ fn happyReduce_445() -> ActionReturn {
 
 fn happyReduction_445(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CAddAssOp, posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CAddAssOp, happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -21070,7 +21070,7 @@ fn happyReduce_446() -> ActionReturn {
 
 fn happyReduction_446(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CSubAssOp, posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CSubAssOp, happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -21082,7 +21082,7 @@ fn happyReduce_447() -> ActionReturn {
 
 fn happyReduction_447(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CShlAssOp, posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CShlAssOp, happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -21094,7 +21094,7 @@ fn happyReduce_448() -> ActionReturn {
 
 fn happyReduction_448(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CShrAssOp, posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CShrAssOp, happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -21106,7 +21106,7 @@ fn happyReduce_449() -> ActionReturn {
 
 fn happyReduction_449(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CAndAssOp, posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CAndAssOp, happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -21118,7 +21118,7 @@ fn happyReduce_450() -> ActionReturn {
 
 fn happyReduction_450(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CXorAssOp, posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(CXorAssOp, happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -21130,7 +21130,7 @@ fn happyReduce_451() -> ActionReturn {
 
 fn happyReduction_451(happy_x_1: HappyAbsSyn) -> HappyAbsSyn {
     match (happy_x_1) {
-        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(COrAssOp,  posOf(happy_var_1))),
+        HappyTerminal(happy_var_1) => HappyAbsSyn121(Located(COrAssOp,  happy_var_1.into_pos())),
         _ => notHappyAtAll()
     }
 }
@@ -21801,7 +21801,10 @@ fn reverseList<a>(l: Vec<a>) -> Reversed<Vec<a>> {
 pub struct Located<T>(T, Position);
 
 impl<T> Pos for Located<T> {
-    fn posOf(self) -> Position {
+    fn pos(&self) -> &Position {
+        &self.1
+    }
+    fn into_pos(self) -> Position {
         self.1
     }
 }
@@ -21813,8 +21816,8 @@ fn unL<T>(Located(a, pos): Located<T>) -> T {
 fn withNodeInfo<T: 'static, N: Pos + 'static>(node: N, mkAttrNode: Box<FnBox(NodeInfo) -> T>) -> P<T> {
     thenP(getNewName(), box |name: Name| {
         thenP(getSavedToken(), box move |lastTok| {
-            let firstPos = posOf(node);
-            let attrs = NodeInfo::new(firstPos, posLenOfTok(lastTok), name);
+            let firstPos = node.into_pos();
+            let attrs = NodeInfo::new(firstPos, movePosLenOfTok(lastTok), name);
             returnP(mkAttrNode(attrs))
         })
     })
@@ -21823,7 +21826,7 @@ fn withNodeInfo<T: 'static, N: Pos + 'static>(node: N, mkAttrNode: Box<FnBox(Nod
 fn withLength<a: Clone + 'static>(nodeinfo: NodeInfo, mkAttrNode: Box<FnBox(NodeInfo) -> a>) -> P<a> {
     thenP(getSavedToken(), box move |lastTok| {
         let firstPos = nodeinfo.pos().clone();
-        let attrs = NodeInfo::new(firstPos, posLenOfTok(lastTok),
+        let attrs = NodeInfo::new(firstPos, movePosLenOfTok(lastTok),
                                   nodeinfo.name().unwrap_or_else(|| panic!("nameOfNode")));
         returnP(mkAttrNode(attrs))
     })
@@ -21837,14 +21840,11 @@ pub struct CDeclrR(Option<Ident>,
                    NodeInfo);
 
 impl CNode for CDeclrR {
-    fn nodeInfo(self) -> NodeInfo {
-        self.4
+    fn node_info(&self) -> &NodeInfo {
+        &self.4
     }
-}
-
-impl Pos for CDeclrR {
-    fn posOf(self) -> Position {
-        posOf(self.4)
+    fn into_node_info(self) -> NodeInfo {
+        self.4
     }
 }
 
@@ -21855,7 +21855,7 @@ fn reverseDeclr(CDeclrR(ide, reversedDDs, asmname, cattrs, at): CDeclrR) -> CDec
 fn withAttribute<node: Pos + 'static>(node: node, cattrs: Vec<CAttribute<NodeInfo>>,
                                       mkDeclrNode: Box<FnBox(NodeInfo) -> CDeclrR>) -> P<CDeclrR> {
     thenP(getNewName(), box move |name| {
-        let attrs = NodeInfo::with_pos_name(node.posOf(), name);
+        let attrs = NodeInfo::with_pos_name(node.into_pos(), name);
         let newDeclr = appendDeclrAttrs(cattrs.clone(), mkDeclrNode(attrs));
         returnP(newDeclr)
     })
@@ -21867,7 +21867,7 @@ fn withAttributePF<N: Pos + 'static>(
 {
     let mkDeclrCtor = Rc::new(mkDeclrCtor);
     thenP(getNewName(), box move |name| {
-        let attrs = NodeInfo::with_pos_name(node.posOf(), name);
+        let attrs = NodeInfo::with_pos_name(node.into_pos(), name);
         let newDeclr: Rc<Box<Fn(CDeclrR) -> CDeclrR>> = Rc::new(box move |_0| {
             appendDeclrAttrs(cattrs.clone(), mkDeclrCtor(attrs.clone(), _0))
         });
@@ -21900,7 +21900,7 @@ fn setAsmName(mAsmName: Option<CStringLiteral<NodeInfo>>,
 
     match combinedName {
         Left((n1, n2)) => {
-            failP(posOf(n2.clone()),
+            failP(n2.pos().clone(),
                   vec!["Duplicate assembler name: ".to_string(), showName(n1), showName(n2)])
         },
         Right(newName) => {
@@ -21984,15 +21984,20 @@ fn addTrailingAttrs(declspecs: Reversed<Vec<CDeclSpec>>,
 // the first thing in the list
 
 impl<A: Pos> Pos for Vec<A> {
-    fn posOf(mut self) -> Position {
-        let item = self.remove(0);
-        posOf(item)
+    fn pos(&self) -> &Position {
+        self[0].pos()
+    }
+    fn into_pos(mut self) -> Position {
+        self.remove(0).into_pos()
     }
 }
 
 impl<A: Pos> Pos for Reversed<A> {
-    fn posOf(self) -> Position {
-        posOf(self.0)
+    fn pos(&self) -> &Position {
+        (self.0).pos()
+    }
+    fn into_pos(self) -> Position {
+        (self.0).into_pos()
     }
 }
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -18390,7 +18390,7 @@ fn happyReduce_237() -> ActionReturn {
 }
 
 refute! { fn happyReduction_237<T>(HappyStk(HappyAbsSyn88(happy_var_2), Some(box HappyStk(HappyTerminal(CTokTyIdent(_, happy_var_1)), Some(box happyRest)))): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
-    happyThen({ withNodeInfo(happy_var_1.clone(), box |at| { happy_var_2(mkVarDeclr(happy_var_1, at)) }) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
+    happyThen({ withNodeInfo(happy_var_1.clone(), box move |at| { happy_var_2(mkVarDeclr(happy_var_1, at)) }) }, (box move |r| { happyReturn(HappyAbsSyn66(r)) }))
 }
 }
 
@@ -20851,8 +20851,9 @@ fn happyReduce_461() -> ActionReturn {
 refute! { fn happyReduction_461<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
                     withNodeInfo(happy_var_1.clone(), box move |_0| {
-                        if let CTokILit(_, i) = happy_var_1 {
-                            CIntConst(i, _0)
+                        // TODO: I don't get why this is a Fn closure...
+                        if let CTokILit(_, ref i) = happy_var_1 {
+                            CIntConst(i.clone(), _0)
                         } else {
                             panic!("irrefutable pattern")
                         }
@@ -20868,8 +20869,8 @@ fn happyReduce_462() -> ActionReturn {
 refute! { fn happyReduction_462<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
                     withNodeInfo(happy_var_1.clone(), box move |_0| {
-                        if let CTokCLit(_, c) = happy_var_1 {
-                            CCharConst(c, _0)
+                        if let CTokCLit(_, ref c) = happy_var_1 {
+                            CCharConst(c.clone(), _0)
                         } else {
                             panic!("irrefutable pattern")
                         }
@@ -20885,8 +20886,8 @@ fn happyReduce_463() -> ActionReturn {
 refute! { fn happyReduction_463<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
                     withNodeInfo(happy_var_1.clone(), box move |_0| {
-                        if let CTokFLit(_, f) = happy_var_1 {
-                            CFloatConst(f, _0)
+                        if let CTokFLit(_, ref f) = happy_var_1 {
+                            CFloatConst(f.clone(), _0)
                         } else {
                             panic!("irrefutable pattern")
                         }
@@ -20902,8 +20903,8 @@ fn happyReduce_464() -> ActionReturn {
 refute! { fn happyReduction_464<T>(HappyStk(HappyTerminal(happy_var_1), Some(box happyRest)): HappyStk<HappyAbsSyn>, tk: T) -> P<HappyAbsSyn> {
     happyThen({
             withNodeInfo(happy_var_1.clone(), box move |_0| {
-                if let CTokSLit(_, s) = happy_var_1 {
-                    CStringLiteral(s, _0)
+                if let CTokSLit(_, ref s) = happy_var_1 {
+                    CStringLiteral(s.clone(), _0)
                 } else {
                     panic!("irrefutable pattern")
                 }

--- a/src/parser/parser_monad.rs
+++ b/src/parser/parser_monad.rs
@@ -102,9 +102,9 @@ impl<a> P<a> {
 //     }
 // }
 
-impl<A: Clone + 'static> From<A> for P<A> {
+impl<A: 'static> From<A> for P<A> {
     fn from(item: A) -> P<A> {
-        P::with(box move |state| POk(state, item.clone()))
+        P::with(box move |state| POk(state, item))
     }
 }
 

--- a/src/parser/tokens.rs
+++ b/src/parser/tokens.rs
@@ -126,8 +126,12 @@ pub enum CToken {
 pub use self::CToken::*;
 
 impl Pos for CToken {
-    fn posOf(self) -> Position {
-        posLenOfTok(self).0
+    fn pos(&self) -> &Position {
+        &posLenOfTok(self).0
+    }
+
+    fn into_pos(self) -> Position {
+        movePosLenOfTok(self).0
     }
 }
 
@@ -156,8 +160,117 @@ pub struct ClangCTok(pub ClangCVersion);
 pub type ClangCVersionTok = ClangCTok;
 
 
-pub fn posLenOfTok(_0: CToken) -> (Position, isize) {
-    match (_0) {
+pub fn posLenOfTok(tok: &CToken) -> &(Position, isize) {
+    match *tok {
+        CTokLParen(ref pos) => pos,
+        CTokRParen(ref pos) => pos,
+        CTokLBracket(ref pos) => pos,
+        CTokRBracket(ref pos) => pos,
+        CTokArrow(ref pos) => pos,
+        CTokDot(ref pos) => pos,
+        CTokExclam(ref pos) => pos,
+        CTokTilde(ref pos) => pos,
+        CTokInc(ref pos) => pos,
+        CTokDec(ref pos) => pos,
+        CTokPlus(ref pos) => pos,
+        CTokMinus(ref pos) => pos,
+        CTokStar(ref pos) => pos,
+        CTokSlash(ref pos) => pos,
+        CTokPercent(ref pos) => pos,
+        CTokAmper(ref pos) => pos,
+        CTokShiftL(ref pos) => pos,
+        CTokShiftR(ref pos) => pos,
+        CTokLess(ref pos) => pos,
+        CTokLessEq(ref pos) => pos,
+        CTokHigh(ref pos) => pos,
+        CTokHighEq(ref pos) => pos,
+        CTokEqual(ref pos) => pos,
+        CTokUnequal(ref pos) => pos,
+        CTokHat(ref pos) => pos,
+        CTokBar(ref pos) => pos,
+        CTokAnd(ref pos) => pos,
+        CTokOr(ref pos) => pos,
+        CTokQuest(ref pos) => pos,
+        CTokColon(ref pos) => pos,
+        CTokAssign(ref pos) => pos,
+        CTokPlusAss(ref pos) => pos,
+        CTokMinusAss(ref pos) => pos,
+        CTokStarAss(ref pos) => pos,
+        CTokSlashAss(ref pos) => pos,
+        CTokPercAss(ref pos) => pos,
+        CTokAmpAss(ref pos) => pos,
+        CTokHatAss(ref pos) => pos,
+        CTokBarAss(ref pos) => pos,
+        CTokSLAss(ref pos) => pos,
+        CTokSRAss(ref pos) => pos,
+        CTokComma(ref pos) => pos,
+        CTokSemic(ref pos) => pos,
+        CTokLBrace(ref pos) => pos,
+        CTokRBrace(ref pos) => pos,
+        CTokEllipsis(ref pos) => pos,
+        CTokAlignof(ref pos) => pos,
+        CTokAlignas(ref pos) => pos,
+        CTokAsm(ref pos) => pos,
+        CTokAtomic(ref pos) => pos,
+        CTokAuto(ref pos) => pos,
+        CTokBreak(ref pos) => pos,
+        CTokBool(ref pos) => pos,
+        CTokCase(ref pos) => pos,
+        CTokChar(ref pos) => pos,
+        CTokConst(ref pos) => pos,
+        CTokContinue(ref pos) => pos,
+        CTokComplex(ref pos) => pos,
+        CTokDefault(ref pos) => pos,
+        CTokDo(ref pos) => pos,
+        CTokDouble(ref pos) => pos,
+        CTokElse(ref pos) => pos,
+        CTokEnum(ref pos) => pos,
+        CTokExtern(ref pos) => pos,
+        CTokFloat(ref pos) => pos,
+        CTokFor(ref pos) => pos,
+        CTokGeneric(ref pos) => pos,
+        CTokGoto(ref pos) => pos,
+        CTokInt(ref pos) => pos,
+        CTokInt128(ref pos) => pos,
+        CTokInline(ref pos) => pos,
+        CTokIf(ref pos) => pos,
+        CTokLong(ref pos) => pos,
+        CTokLabel(ref pos) => pos,
+        CTokNoreturn(ref pos) => pos,
+        CTokNullable(ref pos) => pos,
+        CTokNonnull(ref pos) => pos,
+        CTokRegister(ref pos) => pos,
+        CTokRestrict(ref pos) => pos,
+        CTokReturn(ref pos) => pos,
+        CTokShort(ref pos) => pos,
+        CTokSigned(ref pos) => pos,
+        CTokSizeof(ref pos) => pos,
+        CTokStatic(ref pos) => pos,
+        CTokStaticAssert(ref pos) => pos,
+        CTokStruct(ref pos) => pos,
+        CTokSwitch(ref pos) => pos,
+        CTokTypedef(ref pos) => pos,
+        CTokTypeof(ref pos) => pos,
+        CTokThread(ref pos) => pos,
+        CTokUnion(ref pos) => pos,
+        CTokUnsigned(ref pos) => pos,
+        CTokVoid(ref pos) => pos,
+        CTokVolatile(ref pos) => pos,
+        CTokWhile(ref pos) => pos,
+        CTokCLit(ref pos, _) => pos,
+        CTokILit(ref pos, _) => pos,
+        CTokFLit(ref pos, _) => pos,
+        CTokSLit(ref pos, _) => pos,
+        CTokIdent(ref pos, _) => pos,
+        CTokTyIdent(ref pos, _) => pos,
+        CTokGnuC(_, ref pos) => pos,
+        CTokClangC(ref pos, _) => pos,
+        CTokEof => panic!("tokenPos: Eof"),
+    }
+}
+
+pub fn movePosLenOfTok(tok: CToken) -> (Position, isize) {
+    match tok {
         CTokLParen(pos) => pos,
         CTokRParen(pos) => pos,
         CTokLBracket(pos) => pos,

--- a/src/support.rs
+++ b/src/support.rs
@@ -89,116 +89,13 @@ pub enum ExitCode {
 }
 pub use self::ExitCode::*;
 
-pub trait Lengthable {
-    fn get_len(&self) -> isize;
-}
-pub fn length<A: Lengthable>(left: A) -> isize {
-    Lengthable::get_len(&left)
-}
-impl<T> Lengthable for Vec<T> {
-    fn get_len(&self) -> isize {
-        self.len() as isize
-    }
-}
-
-pub trait Bindable<T> {
-    fn bind_it(self, right: T) -> Self;
-}
-pub fn __op_bind<A: Bindable<B>, B>(left: A, b: B) -> A {
-    Bindable::bind_it(left, b)
-}
-impl<T: Display> Bindable<T> for String {
-    fn bind_it(mut self, right: T) -> Self {
-        // TODO
-        self.push_str(&format!("{}", right));
-        self
-    }
-}
-
-
 pub fn __op_forwardslash<A, B>(left: A, right: B) -> B {
     // TODO
     right
 }
 
-pub fn __op_dollarnot<A, B>(left: A, right: B) -> B {
-    // TODO
-    right
-}
-
-
-pub fn union<A: PartialEq>(mut left: Vec<A>, right: Vec<A>) -> Vec<A> {
-    for item in right {
-        if left.iter().position(|x| *x == item).is_none() {
-            left.push(item);
-        }
-    }
-    left
-}
-
-pub fn toInteger<T: Display>(left: T) -> isize {
-    // TODO
-    0
-}
-
-pub fn fromInteger(left: isize) -> String {
-    // TODO
-    "".to_string()
-}
-
-pub fn shiftL(l: isize, r: isize) -> isize {
-    l << r
-}
-
-pub fn shiftR(l: isize, r: isize) -> isize {
-    l >> r
-}
-
-pub fn fromEnum<A: ToPrimitive>(arg: A) -> isize {
-    arg.to_isize().unwrap()
-}
-
-pub fn __op_dotted_and(l: isize, r: isize) -> isize {
-    l & r
-}
-
-pub fn __op_dotted_or(l: isize, r: isize) -> isize {
-    l | r
-}
-
 pub fn __op_assign_div(l: isize, r: isize) -> isize {
     l / r
-}
-
-pub fn __op_tuple2<A, B>(left: A, right: B) -> (A, B) {
-    (left, right)
-}
-
-pub fn __op_power(l: isize, r: isize) -> isize {
-    //TODO
-    l
-}
-
-pub fn __mod(l: isize, r: isize) -> isize {
-    // TODO
-    l
-}
-
-pub fn not(left: bool) -> bool {
-    !left
-}
-
-pub fn __break<T: Clone, F: Fn(T) -> bool>(cond: F, input: Vec<T>) -> (Vec<T>, Vec<T>) {
-    let mut left = vec![];
-    let mut right = vec![];
-    for item in input.into_iter() {
-        if right.is_empty() && cond(item.clone()) {
-            left.push(item);
-        } else {
-            right.push(item);
-        }
-    }
-    (left, right)
 }
 
 pub fn __break_str<F: Fn(char) -> bool>(cond: F, input: String) -> (String, String) {
@@ -259,27 +156,12 @@ pub fn isDigit(input: char) -> bool {
     false
 }
 
-pub fn head(input: Vec<char>) -> char {
-    input[0]
-}
 
-pub fn head_str(input: String) -> char {
-    input.chars().nth(0).unwrap()
-}
-
-pub fn init(mut input: Vec<char>) -> Vec<char> {
-    input.pop();
-    input
-}
 
 pub fn init_str(input: String) -> String {
     let mut v: Vec<_> = input.chars().collect();
     v.pop();
     v.into_iter().collect()
-}
-
-pub fn tail(input: Vec<char>) -> Vec<char> {
-    input[1..].to_vec()
 }
 
 pub fn tail_str(input: String) -> String {
@@ -290,16 +172,8 @@ pub fn fst<A, B>(input: (A, B)) -> A {
     input.0
 }
 
-pub fn snd<A, B>(input: (A, B)) -> B {
-    input.1
-}
-
 pub fn flip<A, B, C, F: Fn(A, B) -> C>(input: F, b: B, a: A) -> C {
     input(a, b)
-}
-
-pub fn take(len: isize, input: Vec<String>) {
-    // TODO
 }
 
 pub fn take_str(len: isize, input: String) -> String {
@@ -321,19 +195,6 @@ pub fn addExtension(fp: FilePath, ext: &str) -> FilePath {
     fp
 }
 
-
-pub fn takeWhile<T: Clone, F: Fn(T) -> bool>(cond: F, input: Vec<T>) -> Vec<T> {
-    let mut left = vec![];
-    for item in input.into_iter() {
-        if cond(item.clone()) {
-            left.push(item);
-        } else {
-            return left
-        }
-    }
-    left
-}
-
 pub fn takeWhile_str<F: Fn(char) -> bool>(cond: F, input: String) -> String {
     let mut left = vec![];
     for item in input.chars() {
@@ -351,43 +212,12 @@ pub fn fromIntegral(left: isize) -> isize {
     left
 }
 
-pub fn drop<T>(len: isize, mut input: Vec<T>) -> Vec<T> {
-    for _ in 0..len {
-        input.remove(0);
-    }
-    input
-}
-
 pub fn drop_str(len: isize, input: String) -> String {
     input.chars().skip(len as usize).collect()
 }
 
-pub fn dropWhile<F: Fn(char) -> bool>(cond: F, input: String) -> String {
-    let mut out = vec![];
-    for item in input.chars() {
-        if cond(item.clone()) && out.is_empty() {
-            // skip
-        } else {
-            out.push(item);
-        }
-    }
-    out.into_iter().collect()
-}
-
 pub fn chr(input: isize) -> char {
     input as u8 as char
-}
-
-pub fn id<A>(input: A) -> A {
-    input
-}
-
-pub fn __boxed_chars(input: String) -> Box<[char]> {
-    input.chars().collect::<Vec<_>>().into_boxed_slice()
-}
-
-pub fn __boxed_slice<T: Sized>(input: Vec<T>) -> Box<[T]> {
-    input.into_boxed_slice()
 }
 
 // bits
@@ -403,50 +233,6 @@ pub fn clearBit(left: isize, right: isize) -> isize {
 pub fn testBit(left: isize, right: isize) -> bool {
     left & (1 << right) != 0
 }
-
-
-
-
-
-
-// Monads
-
-pub fn __return<A: Into<B>, B>(left: A) -> B {
-    left.into()
-}
-// pub trait Functor {
-//   fmap = liftM
-// }
-
-// pub trait Applicative P where
-//   pure = return
-//   (<*>) = ap
-
-// pub trait Monad<P> {
-//   fn ret(Self) -> Self;
-//   fn bind(Self) -> Self;
-//   fn fail(m) -> Self;
-// }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 // ShowS, ReadS
@@ -552,15 +338,6 @@ macro_rules! __map {
 }
 
 #[macro_export]
-macro_rules! __fmap {
-    ($fn: expr, $target: expr) => {
-        $target.into_iter()
-            .map($fn)
-            .collect::<Vec<_>>()
-    }
-}
-
-#[macro_export]
 macro_rules! __concatMap {
     ($fn: expr, $target: expr) => {
         $target.into_iter()
@@ -568,18 +345,6 @@ macro_rules! __concatMap {
             .collect::<Vec<_>>()
     }
 }
-
-#[macro_export]
-macro_rules! __foldr {
-    ($fn: expr, $target: expr) => {
-        $target.into_iter()
-            .map($fn)
-            .collect::<Vec<_>>()
-    }
-}
-
-
-
 
 
 // IO fns
@@ -643,101 +408,14 @@ pub fn takeFileName(h: FilePath) -> FilePath {
     h
 }
 
-
-
-
 // TODO what do we do here:
 
 pub fn maybe<A, B, F: Fn(A) -> B>(default_: B, method: F, maybe: Option<A>) -> B {
     maybe.map(|x| method(x)).unwrap_or(default_)
 }
 
-pub fn bracket<A, B, C>(a: A, b: B, c: C) -> C {
-    // TODO these are all methods
-    c
-}
-
-
-pub fn seq<A, B>(a: A, b: B) -> B {
-    // we don't do lazy
-    b
-}
-
-
-
-
-
-
-// Map things
-
-pub mod Map {
-    pub fn insert<T>(mut okay: Vec<T>, key: isize, value: T) -> Vec<T> {
-        okay.push(value);
-        okay
-    }
-
-    pub fn lookup<T>(value: T, inside: Vec<T>) -> isize {
-        //TODO
-        0
-    }
-}
-
-
-use std::hash::Hash;
-use std::fmt::Debug;
-use std::collections::HashSet;
-
-#[derive(Clone, Debug)]
-pub struct Set<T: Eq + Hash>(HashSet<T>);
-
-impl<T: Eq + Hash + Debug> Set<T> {
-    pub fn member(item: T, list: Self) -> bool {
-        list.0.contains(&item)
-    }
-
-    pub fn fromList(list: Vec<T>) -> Self {
-        // TODO
-        Set(HashSet::new())
-    }
-
-    pub fn insert(item: T, mut list: Self) -> Self {
-        list.0.insert(item);
-        list
-    }
-
-    pub fn delete(item: T, mut list: Self) -> Self {
-        list.0.remove(&item);
-        list
-    }
-}
-
-
 // Array things
-
-pub fn array<T>(dim: (isize, isize), mut list: Vec<(isize, T)>) -> Vec<T> {
-    // Only supports an ordered array for now
-    list.sort_by(|a, b| a.0.cmp(&b.0));
-    assert_eq!(list.last().unwrap().0, dim.1 - 1);
-    list.into_iter().map(|x| x.1).collect()
-}
-
-pub fn listArray<T>(dim: (isize, isize), list: Vec<T>) -> Vec<T> {
-    list
-}
-
-pub struct Array<T, U> {
-    idx: Vec<T>,
-    inner: Vec<U>,
-}
 
 pub fn __op_array_index<T>(mut arr: Vec<T>, idx: isize) -> T {
     arr.remove(idx as usize)
 }
-
-pub fn __op_rshift(left: isize, right: isize) {
-    // TODO
-    unreachable!();
-}
-
-
-

--- a/src/support.rs
+++ b/src/support.rs
@@ -374,19 +374,6 @@ pub fn dropWhile<F: Fn(char) -> bool>(cond: F, input: String) -> String {
     out.into_iter().collect()
 }
 
-pub fn span<F: Fn(char) -> bool>(cond: F, input: String) -> (String, String) {
-    let mut left = vec![];
-    let mut right = vec![];
-    for item in input.chars() {
-        if cond(item.clone()) && right.is_empty() {
-            left.push(item);
-        } else {
-            right.push(item);
-        }
-    }
-    (left.into_iter().collect(), right.into_iter().collect())
-}
-
 pub fn chr(input: isize) -> char {
     input as u8 as char
 }
@@ -546,87 +533,6 @@ impl ReadS<isize> for readDec {
         }
     }
 }
-
-
-
-
-
-
-// BSC
-
-
-// Char8
-//TODO make this deal with u8's, not chars
-pub mod BSC {
-    pub fn head(input: Vec<u8>) -> char {
-        input[0] as char
-    }
-
-    pub fn tail(input: Vec<u8>) -> Vec<u8> {
-        if input.len() > 0 {
-            input[1..].to_vec()
-        } else {
-            vec![]
-        }
-    }
-
-    pub fn null(input: Vec<u8>) -> bool {
-        input.is_empty()
-    }
-
-    pub fn lines(input: Vec<u8>) -> Vec<Vec<u8>> {
-        //TODO
-        vec![]
-    }
-
-    pub fn pack(input: String) -> Vec<u8> {
-        input.chars().map(|x| x as u8).collect()
-    }
-
-    pub fn unpack(input: Vec<u8>) -> String {
-        input.into_iter().map(|x| x as char).collect()
-    }
-
-    pub fn take(len: isize, input: Vec<u8>) -> Vec<u8> {
-        input.into_iter().take(len as usize).collect()
-    }
-}
-
-// ByteString
-pub mod BSW {
-    use FilePath;
-
-    pub fn null(input: Vec<u8>) -> bool {
-        input.is_empty()
-    }
-
-    pub fn head(input: Vec<u8>) -> u8 {
-        input[0]
-    }
-
-    pub fn tail(input: Vec<u8>) -> Vec<u8> {
-        if input.len() > 0 {
-            input[1..].to_vec()
-        } else {
-            vec![]
-        }
-    }
-
-    pub fn readFile(f: FilePath) -> Vec<u8> {
-        use std::fs::File;
-        use std::io::Read;
-
-        // TODO
-        let mut items = vec![];
-        File::open(f.path).unwrap().read_to_end(&mut items).unwrap();
-        items
-    }
-}
-
-pub type ByteString = Vec<u8>;
-
-pub type Word8 = u8;
-
 
 
 // Map stuff

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -10,7 +10,6 @@ use data::node::*;
 use data::ident::*;
 use syntax::ops::*;
 use syntax::constants::*;
-use data::position::posOf;
 use data::position::{Position, Pos};
 
 use parser_c_macro::CNodeable;

--- a/src/syntax/preprocess.rs
+++ b/src/syntax/preprocess.rs
@@ -115,7 +115,7 @@ pub fn runPreprocessor<P: Preprocessor>(cpp: P,
             }));
 
             match exit_code {
-                ExitSuccess => Ok(readInputStream(actual_out_file)),
+                ExitSuccess => Ok(InputStream::from_file(&actual_out_file)),
                 ExitFailure(_) => Err(exit_code),
             }
         }


### PR DESCRIPTION
I made the Parser monad use `FnBox` instead of `Fn`, so that all closures can take ownership and drop values after they are called. This works because `P<T>` values are only used once - that's an important property for closure-based monads in Haskell as well (to get the desired sequencing).

My clones of Alex/Happy have been updated to generate the code that is in these commits.

Another very important change is in `input_stream`, which keeps a cloneable stream by just referring to an `Rc<Vec<u8>>`. This gets rid of the huge burden of cloning the input string (potentially multiple times) for every char the lexer sees...