### PR TITLE
Make all tests run in their own thread.

### DIFF
--- a/src/bin/dump.rs
+++ b/src/bin/dump.rs
@@ -1,0 +1,13 @@
+extern crate parser_c;
+
+use std::env;
+
+use parser_c::parseCFilePre;
+use parser_c::support::FilePath;
+
+fn main() {
+    let mut args = env::args();
+    let input_file = FilePath { path: args.nth(1).unwrap() };
+    let out = parseCFilePre(input_file);
+    println!("{:#?}", out);
+}

--- a/tests/eval_smoke.rs
+++ b/tests/eval_smoke.rs
@@ -2,7 +2,7 @@ extern crate parser_c;
 extern crate walkdir;
 
 use parser_c::parse;
-use std::fs;
+use std::fs::File;
 use walkdir::WalkDir;
 use std::io::prelude::*;
 
@@ -12,13 +12,13 @@ fn eval_smoke() {
         if let Ok(entry) = item {
             if entry.path().display().to_string().ends_with(".c") {
                 let mut input = String::new();
-                let _ = fs::File::open(entry.path()).unwrap().read_to_string(&mut input);
+                File::open(entry.path()).unwrap().read_to_string(&mut input).unwrap();
                 match parse(&input, &entry.path().display().to_string()) {
                     Err(err) => {
                         panic!("error: {:?}", err);
                     }
                     Ok(_) => {
-                        println!("smoke test passed: {:?}", entry.path());
+                        println!("smoke test passed: {}", entry.path().display());
                     }
                 }
             }

--- a/tests/simple_file.rs
+++ b/tests/simple_file.rs
@@ -1,18 +1,15 @@
 extern crate parser_c;
 
-use parser_c::parser::parser::parseC;
-use parser_c::data::position::Position;
+use parser_c::parseCFilePre;
 use parser_c::support::FilePath;
-use parser_c::data::input_stream::readInputStream;
 
 #[test]
-fn simple() {
+fn simple_file() {
     let input_file = FilePath {
         path: "./tests/simple_file.c".to_owned(),
     };
-    let input_stream = readInputStream(input_file.clone());
 
-    let todo = parseC(input_stream, Position::from_file(input_file));
+    let todo = parseCFilePre(input_file);
 
     println!("OUT {:#?}", todo);
 }


### PR DESCRIPTION
Also add an executable that just parses and dumps a (preprocessed) input file.